### PR TITLE
SFTP to batch WIP - don't merge

### DIFF
--- a/spring-cloud-starter-stream-source-sftp/README.adoc
+++ b/spring-cloud-starter-stream-source-sftp/README.adoc
@@ -79,6 +79,17 @@ $$file.consumer.mode$$:: $$The FileReadingMode to use for file reading sources.
 $$file.consumer.with-markers$$:: $$Set to true to emit start of file/end of file marker messages before/after the data.
  	Only valid with FileReadingMode 'lines'.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$sftp.auto-create-local-dir$$:: $$Set to true to create the local directory if it does not exist.$$ *($$Boolean$$, default: `$$true$$`)*
+$$sftp.batch.batch-resource-uri$$:: $$The URI of the batch artifact to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
+$$sftp.batch.data-source-password$$:: $$The datasource password to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
+$$sftp.batch.data-source-url$$:: $$The datasource url to be applied to the TaskLaunchRequest. Defaults to h2 in-memory
+ JDBC datasource url.$$ *($$String$$, default: `$$jdbc:h2:tcp://localhost:19092/mem:dataflow$$`)*
+$$sftp.batch.data-source-user-name$$:: $$The datasource user name to be applied to the TaskLaunchRequest. Defaults to "sa"$$ *($$String$$, default: `$$sa$$`)*
+$$sftp.batch.deployment-properties$$:: $$Comma delimited list of deployment properties to be applied to the
+ TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
+$$sftp.batch.job-parameters$$:: $$Comma separated list of optional job parameters in key=value format.$$ *($$List<String>$$, default: `$$<none>$$`)*
+$$sftp.batch.local-file-path-job-parameter-name$$:: $$Value to use as the local file job parameter name. Defaults to "localFilePath".$$ *($$String$$, default: `$$localFilePath$$`)*
+$$sftp.batch.local-file-path-job-parameter-value$$:: $$The file path to use as the local file job parameter value. Defaults to "java.io.tmpdir".$$ *($$String$$, default: `$$<none>$$`)*
+$$sftp.batch.remote-file-path-job-parameter-name$$:: $$Value to use as the remote file job parameter name. Defaults to "remoteFilePath".$$ *($$String$$, default: `$$remoteFilePath$$`)*
 $$sftp.delete-remote-files$$:: $$Set to true to delete remote files after successful transfer.$$ *($$Boolean$$, default: `$$false$$`)*
 $$sftp.factory.allow-unknown-keys$$:: $$True to allow an unknown or changed key.$$ *($$Boolean$$, default: `$$false$$`)*
 $$sftp.factory.cache-sessions$$:: $$Cache sessions$$ *($$Boolean$$, default: `$$<none>$$`)*
@@ -91,11 +102,13 @@ $$sftp.factory.private-key$$:: $$Resource location of user's private key.$$ *($$
 $$sftp.factory.username$$:: $$The username to use to connect to the server.$$ *($$String$$, default: `$$<none>$$`)*
 $$sftp.filename-pattern$$:: $$A filter pattern to match the names of files to transfer.$$ *($$String$$, default: `$$<none>$$`)*
 $$sftp.filename-regex$$:: $$A filter regex pattern to match the names of files to transfer.$$ *($$Pattern$$, default: `$$<none>$$`)*
+$$sftp.list-only$$:: $$Set to true to return file metadata without the entire payload.$$ *($$Boolean$$, default: `$$false$$`)*
 $$sftp.local-dir$$:: $$The local directory to use for file transfers.$$ *($$File$$, default: `$$<none>$$`)*
 $$sftp.preserve-timestamp$$:: $$Set to true to preserve the original timestamp.$$ *($$Boolean$$, default: `$$true$$`)*
 $$sftp.remote-dir$$:: $$The remote FTP directory.$$ *($$String$$, default: `$$/$$`)*
 $$sftp.remote-file-separator$$:: $$The remote file separator.$$ *($$String$$, default: `$$/$$`)*
 $$sftp.stream$$:: $$Set to true to stream the file rather than copy to a local directory.$$ *($$Boolean$$, default: `$$false$$`)*
+$$sftp.task-launcher-output$$:: $$Set to true to create output suitable for a task launch request.$$ *($$Boolean$$, default: `$$false$$`)*
 $$sftp.tmp-file-suffix$$:: $$The suffix to use while the transfer is in progress.$$ *($$String$$, default: `$$.tmp$$`)*
 $$trigger.cron$$:: $$Cron expression value for the Cron Trigger.$$ *($$String$$, default: `$$<none>$$`)*
 $$trigger.date-format$$:: $$Format for the date value.$$ *($$String$$, default: `$$<none>$$`)*

--- a/spring-cloud-starter-stream-source-sftp/pom.xml
+++ b/spring-cloud-starter-stream-source-sftp/pom.xml
@@ -23,6 +23,14 @@
 			<artifactId>spring-integration-java-dsl</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-redis</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-file-common</artifactId>
 		</dependency>
@@ -41,6 +49,11 @@
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-trigger-unlimited-common</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-task-stream</artifactId>
+			<version>1.2.2.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceConfiguration.java
@@ -28,11 +28,17 @@ import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.app.file.FileConsumerProperties;
 import org.springframework.cloud.stream.app.file.FileUtils;
 import org.springframework.cloud.stream.app.file.remote.RemoteFileDeletingTransactionSynchronizationProcessor;
+import org.springframework.cloud.stream.app.sftp.source.metadata.SftpSourceRedisIdempotentReceiverConfiguration;
+import org.springframework.cloud.stream.app.sftp.source.tasklauncher.SftpSourceTaskLauncherConfiguration;
 import org.springframework.cloud.stream.app.trigger.TriggerConfiguration;
 import org.springframework.cloud.stream.app.trigger.TriggerPropertiesMaxMessagesDefaultUnlimited;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.integration.annotation.IdempotentReceiver;
+import org.springframework.integration.annotation.Transformer;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlowBuilder;
 import org.springframework.integration.dsl.IntegrationFlows;
@@ -41,17 +47,23 @@ import org.springframework.integration.dsl.sftp.Sftp;
 import org.springframework.integration.dsl.sftp.SftpInboundChannelAdapterSpec;
 import org.springframework.integration.dsl.support.Consumer;
 import org.springframework.integration.file.filters.ChainFileListFilter;
+import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.metadata.SimpleMetadataStore;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.integration.sftp.filters.SftpPersistentAcceptOnceFileListFilter;
 import org.springframework.integration.sftp.filters.SftpRegexPatternFileListFilter;
 import org.springframework.integration.sftp.filters.SftpSimplePatternFileListFilter;
+import org.springframework.integration.sftp.gateway.SftpOutboundGateway;
 import org.springframework.integration.sftp.inbound.SftpStreamingMessageSource;
 import org.springframework.integration.sftp.session.SftpRemoteFileTemplate;
+import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.transaction.DefaultTransactionSynchronizationFactory;
 import org.springframework.integration.transaction.PseudoTransactionManager;
 import org.springframework.integration.transaction.TransactionSynchronizationProcessor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
 import org.springframework.transaction.interceptor.MatchAlwaysTransactionAttributeSource;
 import org.springframework.transaction.interceptor.TransactionInterceptor;
 import org.springframework.util.StringUtils;
@@ -61,14 +73,16 @@ import com.jcraft.jsch.ChannelSftp.LsEntry;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Chris Schaefer
  */
 @EnableBinding(Source.class)
 @EnableConfigurationProperties({ SftpSourceProperties.class, FileConsumerProperties.class })
 @Import({ TriggerConfiguration.class,
 		SftpSourceSessionFactoryConfiguration.class,
-		TriggerPropertiesMaxMessagesDefaultUnlimited.class })
+		TriggerPropertiesMaxMessagesDefaultUnlimited.class,
+		SftpSourceRedisIdempotentReceiverConfiguration.class,
+		SftpSourceTaskLauncherConfiguration.class })
 public class SftpSourceConfiguration {
-
 	@Autowired
 	@Qualifier("defaultPoller")
 	private PollerMetadata defaultPoller;
@@ -80,10 +94,34 @@ public class SftpSourceConfiguration {
 	private SftpRemoteFileTemplate sftpTemplate;
 
 	@Bean
+	public MessageChannel sftpFileListChannel() {
+		return new DirectChannel();
+	}
+
+	@Bean
+	public MessageChannel sftpFileTaskLaunchChannel() {
+		return new DirectChannel();
+	}
+
+	@Bean
 	public IntegrationFlow sftpInboundFlow(SessionFactory<LsEntry> sftpSessionFactory, SftpSourceProperties properties,
 			FileConsumerProperties fileConsumerProperties) {
 		IntegrationFlowBuilder flowBuilder;
-		if (!properties.isStream()) {
+
+		if (properties.isStream()) {
+			flowBuilder = FileUtils.enhanceStreamFlowForReadingMode(
+					IntegrationFlows.from(streamSource(sftpSessionFactory, properties),
+							properties.isDeleteRemoteFiles() ? consumerSpecWithDelete(properties) : consumerSpec()),
+					fileConsumerProperties);
+		}
+		else if (properties.isListOnly() || properties.isTaskLauncherOutput()) {
+			return IntegrationFlows.from(sftpInboundMessageSource(properties), consumerSpec())
+					.handle(sftpGatewayMessageHandler(sftpSessionFactory))
+					.split()
+					.channel(properties.isListOnly() ? sftpFileListChannel() : sftpFileTaskLaunchChannel())
+					.get();
+		}
+		else {
 			SftpInboundChannelAdapterSpec messageSourceBuilder = Sftp.inboundAdapter(sftpSessionFactory)
 					.preserveTimestamp(properties.isPreserveTimestamp())
 					.remoteDirectory(properties.getRemoteDir())
@@ -103,12 +141,7 @@ public class SftpSourceConfiguration {
 			flowBuilder = FileUtils.enhanceFlowForReadingMode(
 					IntegrationFlows.from(messageSourceBuilder, consumerSpec()), fileConsumerProperties);
 		}
-		else {
-			flowBuilder = FileUtils.enhanceStreamFlowForReadingMode(
-					IntegrationFlows.from(streamSource(sftpSessionFactory, properties),
-							properties.isDeleteRemoteFiles() ? consumerSpecWithDelete(properties) : consumerSpec()),
-					fileConsumerProperties);
-		}
+
 		return flowBuilder
 				.channel(this.source.output())
 				.get();
@@ -168,4 +201,27 @@ public class SftpSourceConfiguration {
 		return new SftpRemoteFileTemplate(sftpSessionFactory);
 	}
 
+	@ConditionalOnProperty(name = "sftp.listOnly")
+	@IdempotentReceiver("idempotentReceiverInterceptor")
+	@Transformer(inputChannel = "sftpFileListChannel", outputChannel = Source.OUTPUT)
+	public Message transformSftpMessage(Message message) {
+		return message;
+	}
+
+	private MessageSource<String> sftpInboundMessageSource(final SftpSourceProperties properties) {
+		return new MessageSource<String>() {
+			@Override
+			public Message<String> receive() {
+				return MessageBuilder.withPayload(properties.getRemoteDir()).build();
+			}
+		};
+	}
+
+	private MessageHandler sftpGatewayMessageHandler(SessionFactory<LsEntry> sftpSessionFactory) {
+		SftpOutboundGateway sftpOutboundGateway = new SftpOutboundGateway(sftpSessionFactory,
+				AbstractRemoteFileOutboundGateway.Command.LS.getCommand(), "payload");
+		sftpOutboundGateway.setOptions(AbstractRemoteFileOutboundGateway.Option.NAME_ONLY.getOption());
+
+		return sftpOutboundGateway;
+	}
 }

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceProperties.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceProperties.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.stream.app.sftp.source;
 import java.io.File;
 import java.util.regex.Pattern;
 
+import javax.validation.constraints.AssertFalse;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotNull;
 
@@ -30,6 +31,7 @@ import org.springframework.validation.annotation.Validated;
 
 /**
  * @author Gary Russell
+ * @author Chris Schaefer
  */
 @ConfigurationProperties("sftp")
 @Validated
@@ -89,6 +91,16 @@ public class SftpSourceProperties {
 	 * Set to true to stream the file rather than copy to a local directory.
 	 */
 	private boolean stream = false;
+
+	/**
+	 * Set to true to return file metadata without the entire payload.
+	 */
+	private boolean listOnly = false;
+
+	/**
+	 * Set to true to create output suitable for a task launch request.
+	 */
+	private boolean taskLauncherOutput = false;
 
 	@NotBlank
 	public String getRemoteDir() {
@@ -171,6 +183,11 @@ public class SftpSourceProperties {
 		return !(this.filenamePattern != null && this.filenameRegex != null);
 	}
 
+	@AssertFalse(message = "listOnly and taskLauncherOutput cannot be used at the same time")
+	public boolean isListOnlyOrTaskLauncher() {
+		return listOnly && taskLauncherOutput;
+	}
+
 	public boolean isStream() {
 		return this.stream;
 	}
@@ -181,6 +198,22 @@ public class SftpSourceProperties {
 
 	public Factory getFactory() {
 		return this.factory;
+	}
+
+	public boolean isTaskLauncherOutput() {
+		return taskLauncherOutput;
+	}
+
+	public void setTaskLauncherOutput(boolean taskLauncherOutput) {
+		this.taskLauncherOutput = taskLauncherOutput;
+	}
+
+	public boolean isListOnly() {
+		return listOnly;
+	}
+
+	public void setListOnly(boolean listOnly) {
+		this.listOnly = listOnly;
 	}
 
 	public static class Factory {

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/batch/SftpSourceBatchProperties.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/batch/SftpSourceBatchProperties.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.sftp.source.batch;
+
+import org.hibernate.validator.constraints.NotBlank;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Chris Schaefer
+ */
+@Validated
+@ConfigurationProperties("sftp.batch")
+public class SftpSourceBatchProperties {
+    protected static final String DEFAULT_LOCAL_FILE_PATH_JOB_PARAM_NAME = "localFilePath";
+    protected static final String DEFAULT_REMOTE_FILE_PATH_JOB_PARAM_NAME = "remoteFilePath";
+
+    /**
+     * The URI of the batch artifact to be applied to the TaskLaunchRequest.
+     */
+    private String batchResourceUri;
+
+    /**
+     * The datasource url to be applied to the TaskLaunchRequest. Defaults to h2 in-memory
+     * JDBC datasource url.
+     */
+    private String dataSourceUrl = "jdbc:h2:tcp://localhost:19092/mem:dataflow";
+
+    /**
+     * The datasource user name to be applied to the TaskLaunchRequest. Defaults to "sa"
+     */
+    private String dataSourceUserName = "sa";
+
+    /**
+     * The datasource password to be applied to the TaskLaunchRequest.
+     */
+    private String dataSourcePassword;
+
+    /**
+     * Comma delimited list of deployment properties to be applied to the
+     * TaskLaunchRequest.
+     */
+    private String deploymentProperties;
+
+    /**
+     * Value to use as the remote file job parameter name. Defaults to "remoteFilePath".
+     */
+    private String remoteFilePathJobParameterName = DEFAULT_REMOTE_FILE_PATH_JOB_PARAM_NAME;
+
+    /**
+     * Value to use as the local file job parameter name. Defaults to "localFilePath".
+     */
+    private String localFilePathJobParameterName = DEFAULT_LOCAL_FILE_PATH_JOB_PARAM_NAME;
+
+    /**
+     * The file path to use as the local file job parameter value. Defaults to "java.io.tmpdir".
+     */
+    private String localFilePathJobParameterValue = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
+
+    /**
+     * Comma separated list of optional job parameters in key=value format.
+     */
+    private List<String> jobParameters = new ArrayList<>();
+
+    @NotBlank
+    public String getBatchResourceUri() {
+        return batchResourceUri;
+    }
+
+    public void setBatchResourceUri(String batchResourceUri) {
+        this.batchResourceUri = batchResourceUri;
+    }
+
+    @NotBlank
+    public String getDataSourceUrl() {
+        return dataSourceUrl;
+    }
+
+    public void setDataSourceUrl(String dataSourceUrl) {
+        this.dataSourceUrl = dataSourceUrl;
+    }
+
+    @NotBlank
+    public String getDataSourceUserName() {
+        return dataSourceUserName;
+    }
+
+    public void setDataSourceUserName(String dataSourceUserName) {
+        this.dataSourceUserName = dataSourceUserName;
+    }
+
+    public String getDataSourcePassword() {
+        return dataSourcePassword;
+    }
+
+    public void setDataSourcePassword(String dataSourcePassword) {
+        this.dataSourcePassword = dataSourcePassword;
+    }
+
+    public String getDeploymentProperties() {
+        return deploymentProperties;
+    }
+
+    public void setDeploymentProperties(String deploymentProperties) {
+        this.deploymentProperties = deploymentProperties;
+    }
+
+    public String getRemoteFilePathJobParameterName() {
+        if (remoteFilePathJobParameterName != null) {
+            return remoteFilePathJobParameterName.trim();
+        }
+
+        return null;
+    }
+
+    public void setRemoteFilePathJobParameterName(String remoteFilePathJobParameterName) {
+        this.remoteFilePathJobParameterName = remoteFilePathJobParameterName;
+    }
+
+    public String getLocalFilePathJobParameterName() {
+        if (localFilePathJobParameterName != null) {
+            return localFilePathJobParameterName.trim();
+        }
+
+        return null;
+    }
+
+    public void setLocalFilePathJobParameterName(String localFilePathJobParameterName) {
+        this.localFilePathJobParameterName = localFilePathJobParameterName;
+    }
+
+    @NotBlank
+    public String getLocalFilePathJobParameterValue() {
+        if (localFilePathJobParameterValue != null) {
+            return localFilePathJobParameterValue;
+        }
+
+        return null;
+    }
+
+    public void setLocalFilePathJobParameterValue(String localFilePathJobParameterValue) {
+        this.localFilePathJobParameterValue = localFilePathJobParameterValue;
+    }
+
+    public List<String> getJobParameters() {
+        return jobParameters;
+    }
+
+    public void setJobParameters(List<String> jobParameters) {
+        this.jobParameters = jobParameters;
+    }
+}

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/metadata/SftpSourceRedisIdempotentReceiverConfiguration.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/metadata/SftpSourceRedisIdempotentReceiverConfiguration.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.sftp.source.metadata;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.integration.channel.NullChannel;
+import org.springframework.integration.handler.ExpressionEvaluatingMessageProcessor;
+import org.springframework.integration.handler.advice.IdempotentReceiverInterceptor;
+import org.springframework.integration.metadata.ConcurrentMetadataStore;
+import org.springframework.integration.redis.metadata.RedisMetadataStore;
+import org.springframework.integration.selector.MetadataStoreSelector;
+import org.springframework.util.Assert;
+
+/**
+ * @author Chris Schaefer
+ */
+@EnableConfigurationProperties({ SftpSourceRedisIdempotentReceiverProperties.class, RedisProperties.class })
+public class SftpSourceRedisIdempotentReceiverConfiguration {
+    protected static final String REMOTE_DIRECTORY_MESSAGE_HEADER = "file_remoteDirectory";
+
+    @Autowired
+    private BeanFactory beanFactory;
+
+    @Autowired
+    private RedisConnectionFactory redisConnectionFactory;
+
+    @Autowired
+    private SftpSourceRedisIdempotentReceiverProperties sftpSourceRedisIdempotentReceiverProperties;
+
+    @Bean
+    @ConditionalOnMissingBean
+    public IdempotentReceiverInterceptor idempotentReceiverInterceptor() {
+        String expressionStatement = new StringBuilder()
+                .append("headers['")
+                .append(REMOTE_DIRECTORY_MESSAGE_HEADER)
+                .append("'].concat(payload)")
+                .toString();
+
+        Expression expression = new SpelExpressionParser().parseExpression(expressionStatement);
+
+        ExpressionEvaluatingMessageProcessor<String> idempotentKeyStrategy =
+                new ExpressionEvaluatingMessageProcessor<>(expression);
+        idempotentKeyStrategy.setBeanFactory(beanFactory);
+
+        IdempotentReceiverInterceptor idempotentReceiverInterceptor =
+                new IdempotentReceiverInterceptor(new MetadataStoreSelector(idempotentKeyStrategy, metadataStore()));
+        idempotentReceiverInterceptor.setDiscardChannel(new NullChannel());
+
+        return idempotentReceiverInterceptor;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ConcurrentMetadataStore metadataStore() {
+        Assert.notNull(redisConnectionFactory, "A RedisConnectionFactory is required.");
+
+        return new RedisMetadataStore(redisConnectionFactory, sftpSourceRedisIdempotentReceiverProperties.getKeyName());
+    }
+}

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/metadata/SftpSourceRedisIdempotentReceiverProperties.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/metadata/SftpSourceRedisIdempotentReceiverProperties.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.sftp.source.metadata;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Chris Schaefer
+ */
+@ConfigurationProperties("sftp.metadata.redis")
+public class SftpSourceRedisIdempotentReceiverProperties {
+    /**
+     * The key name to use when storing file metadata. Defaults to "sftpSource".
+     */
+    private String keyName = "sftpSource";
+
+    public String getKeyName() {
+        return keyName;
+    }
+
+    public void setKeyName(String keyName) {
+        this.keyName = keyName;
+    }
+}

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherConfiguration.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherConfiguration.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.sftp.source.tasklauncher;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.stream.app.sftp.source.SftpSourceProperties;
+import org.springframework.cloud.stream.app.sftp.source.batch.SftpSourceBatchProperties;
+import org.springframework.cloud.stream.app.sftp.source.metadata.SftpSourceRedisIdempotentReceiverConfiguration;
+import org.springframework.cloud.stream.messaging.Source;
+import org.springframework.cloud.task.launcher.TaskLaunchRequest;
+import org.springframework.context.annotation.Import;
+import org.springframework.integration.annotation.IdempotentReceiver;
+import org.springframework.integration.annotation.Transformer;
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Chris Schaefer
+ */
+@ConditionalOnProperty(name = "sftp.taskLauncherOutput")
+@EnableConfigurationProperties({ SftpSourceProperties.class, SftpSourceBatchProperties.class })
+@Import({ SftpSourceRedisIdempotentReceiverConfiguration.class })
+public class SftpSourceTaskLauncherConfiguration {
+    protected static final String SFTP_HOST_PROPERTY_KEY = "sftp_host";
+    protected static final String SFTP_PORT_PROPERTY_KEY = "sftp_port";
+    protected static final String SFTP_USERNAME_PROPERTY_KEY = "sftp_username";
+    protected static final String SFTP_PASSWORD_PROPERTY_KEY = "sftp_password";
+    protected static final String DATASOURCE_URL_PROPERTY_KEY = "spring_datasource_url";
+    protected static final String DATASOURCE_USERNAME_PROPERTY_KEY = "spring_datasource_username";
+    protected static final String REMOTE_DIRECTORY_MESSAGE_HEADER = "file_remoteDirectory";
+
+    @Autowired
+    private SftpSourceProperties sftpSourceProperties;
+
+    @Autowired
+    private SftpSourceBatchProperties sftpSourceBatchProperties;
+
+    @IdempotentReceiver("idempotentReceiverInterceptor")
+    @Transformer(inputChannel = "sftpFileTaskLaunchChannel", outputChannel = Source.OUTPUT)
+    public TaskLaunchRequest sftpFileTaskLauncherTransfomer(Message message) {
+        return new TaskLaunchRequest(sftpSourceBatchProperties.getBatchResourceUri(), getCommandLineArgs(message),
+                getEnvironmentProperties(), null, null);
+    }
+
+    private Map<String, String> getEnvironmentProperties() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(DATASOURCE_URL_PROPERTY_KEY, sftpSourceBatchProperties.getDataSourceUrl());
+        properties.put(DATASOURCE_USERNAME_PROPERTY_KEY, sftpSourceBatchProperties.getDataSourceUserName());
+        properties.put(SFTP_HOST_PROPERTY_KEY, sftpSourceProperties.getFactory().getHost());
+        properties.put(SFTP_USERNAME_PROPERTY_KEY, sftpSourceProperties.getFactory().getUsername());
+        properties.put(SFTP_PASSWORD_PROPERTY_KEY, sftpSourceProperties.getFactory().getPassword());
+        properties.put(SFTP_PORT_PROPERTY_KEY, String.valueOf(sftpSourceProperties.getFactory().getPort()));
+
+        return properties;
+    }
+
+    private List<String> getCommandLineArgs(Message message) {
+        Assert.notNull(message, "Message to create TaskLaunchRequest from cannot be null");
+
+        String filename = (String) message.getPayload();
+        String remoteDirectory = (String) message.getHeaders().get(REMOTE_DIRECTORY_MESSAGE_HEADER);
+        String localFilePathJobParameterValue = sftpSourceBatchProperties.getLocalFilePathJobParameterValue();
+
+        String remoteFilePath = buildFilePath(remoteDirectory, filename);
+        String localFilePath = buildFilePath(localFilePathJobParameterValue, filename);
+        String localFilePathJobParameterName = sftpSourceBatchProperties.getLocalFilePathJobParameterName();
+        String remoteFilePathJobParameterName = sftpSourceBatchProperties.getRemoteFilePathJobParameterName();
+
+        List<String> commandLineArgs = new ArrayList<>();
+        commandLineArgs.add(remoteFilePathJobParameterName + "=" + remoteFilePath);
+        commandLineArgs.add(localFilePathJobParameterName + "=" + localFilePath);
+        commandLineArgs.addAll(sftpSourceBatchProperties.getJobParameters());
+
+        return commandLineArgs;
+    }
+
+    private String buildFilePath(String directory, String filename) {
+        StringBuilder sftpUri = new StringBuilder()
+                .append(directory);
+
+        if (!directory.endsWith("/")) {
+            sftpUri.append("/");
+        }
+
+        sftpUri.append(filename);
+
+        return sftpUri.toString();
+    }
+}

--- a/spring-cloud-starter-stream-source-sftp/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
+++ b/spring-cloud-starter-stream-source-sftp/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
@@ -1,4 +1,5 @@
 configuration-properties.classes=org.springframework.cloud.stream.app.sftp.source.SftpSourceProperties, \
+  org.springframework.cloud.stream.app.sftp.source.batch.SftpSourceBatchProperties, \
   org.springframework.cloud.stream.app.sftp.source.SftpSourceProperties$Factory, \
   org.springframework.cloud.stream.app.file.FileConsumerProperties, \
   org.springframework.cloud.stream.app.trigger.TriggerPropertiesMaxMessagesDefaultUnlimited, \

--- a/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/SftpSourcePropertiesTests.java
+++ b/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/SftpSourcePropertiesTests.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 
@@ -120,6 +121,39 @@ public class SftpSourcePropertiesTests {
 		assertThat(properties.getRemoteFileSeparator(), equalTo("\\"));
 	}
 
+	@Test
+	public void listOnlyCanBeCustomized() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(context, "sftp.listOnly:true");
+		context.register(Conf.class);
+		context.refresh();
+		SftpSourceProperties properties = context.getBean(SftpSourceProperties.class);
+		assertTrue(properties.isListOnly());
+	}
+
+	@Test
+	public void taskLauncherOutputCanBeCustomized() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(context, "sftp.taskLauncherOutput:true");
+		context.register(Conf.class);
+		context.refresh();
+		SftpSourceProperties properties = context.getBean(SftpSourceProperties.class);
+		assertTrue(properties.isTaskLauncherOutput());
+	}
+
+	@Test(expected = AssertionError.class)
+	public void onlyAllowListOnlyOrTaskLauncherOutputEnabled() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(context, "sftp.listOnly:true");
+		EnvironmentTestUtils.addEnvironment(context, "sftp.taskLauncherOutput:true");
+		context.register(Conf.class);
+
+		try {
+			context.refresh();
+		} catch (Exception e) { }
+
+		fail("listOnly and taskLauncherOutput cannot be enabled at the same time.");
+	}
 
 	@Test
 	public void preserveTimestampDirCanBeDisabled() {

--- a/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/batch/SftpSourceBatchPropertiesTests.java
+++ b/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/batch/SftpSourceBatchPropertiesTests.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.sftp.source.batch;
+
+import org.junit.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.cloud.stream.config.SpelExpressionConverterConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.integration.config.EnableIntegration;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Chris Schaefer
+ */
+public class SftpSourceBatchPropertiesTests {
+    @Test
+    public void batchUriCanBeCustomized() {
+        SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.batchResourceUri:uri:/somewhere");
+        assertThat(properties.getBatchResourceUri(), equalTo("uri:/somewhere"));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void batchUriIsRequired() {
+        validateRequiredProperty("sftp.batch.batchResourceUri");
+    }
+
+    @Test
+    public void dataSourceUrlCanBeCustomized() {
+        SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.dataSourceUrl:jdbc:h2:tcp://localhost/mem:df");
+        assertThat(properties.getDataSourceUrl(), equalTo("jdbc:h2:tcp://localhost/mem:df"));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void dataSourceUrlIsRequired() {
+        validateRequiredProperty("sftp.batch.dataSourceUrl");
+    }
+
+    @Test
+    public void dataSourceUsernameCanBeCustomized() {
+        SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.dataSourceUserName:user");
+        assertThat(properties.getDataSourceUserName(), equalTo("user"));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void dataSourceUsernameIsRequired() {
+        validateRequiredProperty("sftp.batch.dataSourceUserName");
+    }
+
+    @Test
+    public void dataSourcePasswordCanBeCustomized() {
+        SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.dataSourcePassword:pass");
+        assertThat(properties.getDataSourcePassword(), equalTo("pass"));
+    }
+
+    @Test
+    public void deploymentPropertiesCanBeCustomized() {
+        SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.deploymentProperties:prop1=val1,prop2=val2");
+        assertThat(properties.getDeploymentProperties(), equalTo("prop1=val1,prop2=val2"));
+    }
+
+    @Test
+    public void remoteFilePathJobParameterNameCanBeCustomized() {
+        SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.remoteFilePathJobParameterName:externalFileName");
+        assertThat(properties.getRemoteFilePathJobParameterName(), equalTo("externalFileName"));
+    }
+
+    @Test
+    public void remoteFilePathJobParameterNameDefault() {
+        SftpSourceBatchProperties properties = getBatchProperties(null);
+        assertThat(properties.getRemoteFilePathJobParameterName(), equalTo(SftpSourceBatchProperties.DEFAULT_REMOTE_FILE_PATH_JOB_PARAM_NAME));
+    }
+
+    @Test
+    public void localFilePathJobParameterNameCanBeCustomized() {
+        SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.localFilePathJobParameterName:localFileName");
+        assertThat(properties.getLocalFilePathJobParameterName(), equalTo("localFileName"));
+    }
+
+    @Test
+    public void localFilePathJobParameterNameDefault() {
+        SftpSourceBatchProperties properties = getBatchProperties(null);
+        assertThat(properties.getLocalFilePathJobParameterName(), equalTo(SftpSourceBatchProperties.DEFAULT_LOCAL_FILE_PATH_JOB_PARAM_NAME));
+    }
+
+    @Test
+    public void localFilePathJobParameterValueCanBeCustomized() {
+        SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.localFilePathJobParameterValue:/home/files");
+        assertThat(properties.getLocalFilePathJobParameterValue(), equalTo("/home/files"));
+    }
+
+    @Test
+    public void jobParametersCanBeCustomized() {
+        SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.jobParameters:jp1=jpv1,jp2=jpv2");
+        List<String> jobParameters = properties.getJobParameters();
+
+        assertNotNull("Job parameters should not be null", jobParameters);
+        assertThat("Expected two job parameters", jobParameters.size() == 2);
+        assertThat(jobParameters.get(0), equalTo("jp1=jpv1"));
+        assertThat(jobParameters.get(1), equalTo("jp2=jpv2"));
+    }
+
+    private SftpSourceBatchProperties getBatchProperties(String var) {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+        if (var != null) {
+            EnvironmentTestUtils.addEnvironment(context, var);
+        }
+
+        // there is no good property default for this required field. add a default if not
+        // testing this property
+        if (!"sftp.batch.batchResourceUri".equals(var)) {
+            EnvironmentTestUtils.addEnvironment(context, "sftp.batch.batchResourceUri:uri:/somewhere");
+        }
+
+        context.register(Conf.class);
+        context.refresh();
+
+        return context.getBean(SftpSourceBatchProperties.class);
+    }
+
+    private void validateRequiredProperty(String property) {
+        try {
+            getBatchProperties(property + ":");
+        } catch (Exception e) { }
+
+
+        fail(property + " is required");
+    }
+
+    @Configuration
+    @EnableIntegration
+    @EnableConfigurationProperties(SftpSourceBatchProperties.class)
+    @Import(SpelExpressionConverterConfiguration.class)
+    static class Conf {
+
+    }
+}

--- a/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherIntegrationTests.java
+++ b/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherIntegrationTests.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.sftp.source.tasklauncher;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.app.test.sftp.SftpTestSupport;
+import org.springframework.cloud.stream.messaging.Source;
+import org.springframework.cloud.stream.test.binder.MessageCollector;
+import org.springframework.cloud.task.launcher.TaskLaunchRequest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.Message;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Chris Schaefer
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = {
+                "sftp.remoteDir = sftpSource",
+                "sftp.factory.username = foo",
+                "sftp.factory.password = foo",
+                "sftp.factory.allowUnknownKeys = true"
+        })
+@DirtiesContext
+public abstract class SftpSourceTaskLauncherIntegrationTests extends SftpTestSupport {
+    @Autowired
+    MessageCollector messageCollector;
+
+    @Autowired
+    Source sftpSource;
+
+    @Autowired
+    RedisTemplate<String, String> redisTemplate;
+
+	@TestPropertySource(properties = { "sftp.taskLauncherOutput = true",
+			"sftp.batch.batchResourceUri = file://some.jar",
+			"sftp.batch.dataSourceUserName = sa",
+			"sftp.batch.dataSourceUrl = jdbc://host:2222/mem",
+			"sftp.batch.localFilePathJobParameterValue = /tmp/files",
+			"sftp.batch.jobParameters = jpk1=jpv1,jpk2=jpv2",
+			"sftp.factory.host = 127.0.0.1",
+			"sftp.factory.username = user",
+			"sftp.factory.password = pass",
+			"sftp.metadata.redis.keyName = sftpSourceTest" })
+	public static class TaskLauncherOutputTests extends SftpSourceTaskLauncherIntegrationTests {
+		@Value("${sftp.metadata.redis.keyName}")
+		private String keyName;
+
+		@Before
+		public void before() {
+			redisTemplate.delete(keyName);
+		}
+
+		@After
+		public void after() {
+			redisTemplate.delete(keyName);
+		}
+
+		@Test
+		public void pollAndAssertFiles() throws InterruptedException {
+			for (int i = 1; i <= 3; i++) {
+				@SuppressWarnings("unchecked")
+                Message<TaskLaunchRequest> received = (Message<TaskLaunchRequest>) this.messageCollector.forChannel(sftpSource.output())
+						.poll(10, TimeUnit.SECONDS);
+
+				if ( i == 3) {
+					assertNull("All files should have been seen already", received);
+				} else {
+					assertNotNull(received);
+
+					TaskLaunchRequest taskLaunchRequest = received.getPayload();
+					assertNotNull(taskLaunchRequest);
+
+					assertEquals("Unexpected number of deployment properties", 0, taskLaunchRequest.getDeploymentProperties().size());
+					assertEquals("Unexpected batch artifact URI", "file://some.jar", taskLaunchRequest.getUri());
+
+					Map<String, String> environmentProperties = taskLaunchRequest.getEnvironmentProperties();
+					assertEquals("Unexpected datasource user name", "sa",
+							environmentProperties.get(SftpSourceTaskLauncherConfiguration.DATASOURCE_USERNAME_PROPERTY_KEY));
+					assertEquals("Unexpected datasource url", "jdbc://host:2222/mem",
+							environmentProperties.get(SftpSourceTaskLauncherConfiguration.DATASOURCE_URL_PROPERTY_KEY));
+					assertEquals("Unexpected SFTP host", "127.0.0.1",
+							environmentProperties.get(SftpSourceTaskLauncherConfiguration.SFTP_HOST_PROPERTY_KEY));
+					assertEquals("Unexpected SFTP username", "user",
+							environmentProperties.get(SftpSourceTaskLauncherConfiguration.SFTP_USERNAME_PROPERTY_KEY));
+					assertEquals("Unexpected SFTP password", "pass",
+							environmentProperties.get(SftpSourceTaskLauncherConfiguration.SFTP_PASSWORD_PROPERTY_KEY));
+					assertNotNull("SFTP port is null",  environmentProperties.get(SftpSourceTaskLauncherConfiguration.SFTP_PORT_PROPERTY_KEY));
+
+					List<String> commandlineArguments = taskLaunchRequest.getCommandlineArguments();
+					assertEquals("Unexpected number of commandline arguments", 4, commandlineArguments.size());
+					assertEquals("Unexpected remote file path", "remoteFilePath=sftpSource/sftpSource" + i + ".txt", commandlineArguments.get(0));
+					assertEquals("Unexpected local file path", "localFilePath=/tmp/files/sftpSource" + i + ".txt", commandlineArguments.get(1));
+					assertEquals("Unexpected job parameter", "jpk1=jpv1", commandlineArguments.get(2));
+					assertEquals("Unexpected job parameter", "jpk2=jpv2", commandlineArguments.get(3));
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This WIP PR implements action items from the discussion of the "Batch File Ingest Sample RFC" document. It provides the ability to list files only without a payload along with packaging that data into a TaskLaunchRequest in the SFTP source. Redis is used as the backing metadata store for tracking seen files. The new stream definition also removes prior duplication and reduced to for example:

`stream create --name inboundSftp --definition "sftp --username=user --password=pass --host=127.0.0.1 --port=6666 --allow-unknown-keys=true --task-launcher-output=true --remote-dir=/tmp/blah --batch-resource-uri=file:////Users/cschaefer/work/dataflow/spring-cloud-dataflow-samples/batch/file-ingest/target/ingest-1.0.0.jar --data-source-url=jdbc:h2:tcp://localhost:19092/mem:dataflow --data-source-user-name=sa --local-file-path-job-parameter-value=/tmp/ | task-launcher-local" --deploy`

This code was branched from 1.3.x as master was failing to build, it will be moved to the appropriate branch.

Tested with the kafka binder and local DF server.

I've added everybody that participated in the call as reviewers to this for feedback. As of now the only functionality missing should be rate limiting of TaskLaunchRequest's as that depends on future work in Spring Cloud Stream(?). 

