### PR TITLE
Set content-type headers for the List-Only and Task-Launcher payloads

### DIFF
--- a/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceIntegrationTests.java
+++ b/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceIntegrationTests.java
@@ -47,9 +47,11 @@ import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.sftp.inbound.SftpStreamingMessageSource;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.MimeTypeUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -204,7 +206,7 @@ public abstract class SftpSourceIntegrationTests extends SftpTestSupport {
 						.poll(10, TimeUnit.SECONDS);
 
 				assertNotNull("No files were received", received);
-
+				assertEquals(MimeTypeUtils.TEXT_PLAIN, received.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 				assertNotNull("Payload is null", received.getPayload());
 				String filename = received.getPayload();
 				assertEquals("Unexpected payload value", "sftpSource/sftpSource" + i + ".txt", filename);


### PR DESCRIPTION
   The content types for the `streaming` and the `default` 
   sftp modes are explicitly set to `text\plain` and `application\json`.
   The `ref` mode should do the same after the https://github.com/spring-cloud-stream-app-starters/core/issues/43
   is resolved.

   The `list-only` and` the `task-launcher` modes though are left with
   empty content-type headers. Therefore the SCSt will set the a default
   content type for them which is `application\json`. Accidentally this
   works because list-only's payload is of type text and the task-launcher
   request can be serialized as JSON.

   To improve the robustness and reliability we should set the content-types
   explicitly to `text\plain` for list-only mode and `application\json` for the task-launcher mode.

Resolves #13
Resolves #14

Related to https://github.com/spring-cloud-stream-app-starters/core/issues/43