### PR TITLE
 GH-12: Support multiple servers/directories

### DIFF
--- a/spring-cloud-starter-stream-source-sftp/README.adoc
+++ b/spring-cloud-starter-stream-source-sftp/README.adoc
@@ -138,7 +138,6 @@ $$sftp.local-dir$$:: $$The local directory to use for file transfers.$$ *($$File
 $$sftp.max-fetch$$:: $$The maximum number of remote files to fetch per poll; default unlimited.
  Does not apply when listing files or building task launch requests.$$ *($$Integer$$, default: `$$<none>$$`)*
 $$sftp.metadata.redis.key-name$$:: $$The key name to use when storing file metadata. Defaults to "sftpSource".$$ *($$String$$, default: `$$sftpSource$$`)*
-$$sftp.multi-source$$:: $$True to allow polling multiple servers/directories.$$ *($$Boolean$$, default: `$$false$$`)*
 $$sftp.preserve-timestamp$$:: $$Set to true to preserve the original timestamp.$$ *($$Boolean$$, default: `$$true$$`)*
 $$sftp.remote-dir$$:: $$The remote FTP directory.$$ *($$String$$, default: `$$/$$`)*
 $$sftp.remote-file-separator$$:: $$The remote file separator.$$ *($$String$$, default: `$$/$$`)*

--- a/spring-cloud-starter-stream-source-sftp/README.adoc
+++ b/spring-cloud-starter-stream-source-sftp/README.adoc
@@ -119,6 +119,8 @@ $$file.consumer.mode$$:: $$The FileReadingMode to use for file reading sources. 
 $$file.consumer.with-markers$$:: $$Set to true to emit start of file/end of file marker messages before/after the data. 	Only valid with FileReadingMode 'lines'.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$sftp.auto-create-local-dir$$:: $$Set to true to create the local directory if it does not exist.$$ *($$Boolean$$, default: `$$true$$`)*
 $$sftp.delete-remote-files$$:: $$Set to true to delete remote files after successful transfer.$$ *($$Boolean$$, default: `$$false$$`)*
+$$sftp.directories$$:: $$A list of factory "name.directory" pairs.$$ *($$String[]$$, default: `$$<none>$$`)*
+$$sftp.factories$$:: $$A map of factory names to factories.$$ *($$Map<String, Factory>$$, default: `$$<none>$$`)*
 $$sftp.factory.allow-unknown-keys$$:: $$True to allow an unknown or changed key.$$ *($$Boolean$$, default: `$$false$$`)*
 $$sftp.factory.cache-sessions$$:: $$Cache sessions$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$sftp.factory.host$$:: $$The host name of the server.$$ *($$String$$, default: `$$localhost$$`)*
@@ -128,10 +130,15 @@ $$sftp.factory.password$$:: $$The password to use to connect to the server.$$ *(
 $$sftp.factory.port$$:: $$The port of the server.$$ *($$Integer$$, default: `$$22$$`)*
 $$sftp.factory.private-key$$:: $$Resource location of user's private key.$$ *($$String$$, default: `$$<empty string>$$`)*
 $$sftp.factory.username$$:: $$The username to use to connect to the server.$$ *($$String$$, default: `$$<none>$$`)*
+$$sftp.fair$$:: $$True for fair polling of multiple servers/directories.$$ *($$Boolean$$, default: `$$false$$`)*
 $$sftp.filename-pattern$$:: $$A filter pattern to match the names of files to transfer.$$ *($$String$$, default: `$$<none>$$`)*
 $$sftp.filename-regex$$:: $$A filter regex pattern to match the names of files to transfer.$$ *($$Pattern$$, default: `$$<none>$$`)*
 $$sftp.list-only$$:: $$Set to true to return file metadata without the entire payload.$$ *($$Boolean$$, default: `$$false$$`)*
 $$sftp.local-dir$$:: $$The local directory to use for file transfers.$$ *($$File$$, default: `$$<none>$$`)*
+$$sftp.max-fetch$$:: $$The maximum number of remote files to fetch per poll; default unlimited.
+ Does not apply when listing files or building task launch requests.$$ *($$Integer$$, default: `$$<none>$$`)*
+$$sftp.metadata.redis.key-name$$:: $$The key name to use when storing file metadata. Defaults to "sftpSource".$$ *($$String$$, default: `$$sftpSource$$`)*
+$$sftp.multi-source$$:: $$True to allow polling multiple servers/directories.$$ *($$Boolean$$, default: `$$false$$`)*
 $$sftp.preserve-timestamp$$:: $$Set to true to preserve the original timestamp.$$ *($$Boolean$$, default: `$$true$$`)*
 $$sftp.remote-dir$$:: $$The remote FTP directory.$$ *($$String$$, default: `$$/$$`)*
 $$sftp.remote-file-separator$$:: $$The remote file separator.$$ *($$String$$, default: `$$/$$`)*

--- a/spring-cloud-starter-stream-source-sftp/README.adoc
+++ b/spring-cloud-starter-stream-source-sftp/README.adoc
@@ -135,9 +135,7 @@ $$sftp.filename-pattern$$:: $$A filter pattern to match the names of files to tr
 $$sftp.filename-regex$$:: $$A filter regex pattern to match the names of files to transfer.$$ *($$Pattern$$, default: `$$<none>$$`)*
 $$sftp.list-only$$:: $$Set to true to return file metadata without the entire payload.$$ *($$Boolean$$, default: `$$false$$`)*
 $$sftp.local-dir$$:: $$The local directory to use for file transfers.$$ *($$File$$, default: `$$<none>$$`)*
-$$sftp.max-fetch$$:: $$The maximum number of remote files to fetch per poll; default unlimited.
- Does not apply when listing files or building task launch requests.$$ *($$Integer$$, default: `$$<none>$$`)*
-$$sftp.metadata.redis.key-name$$:: $$The key name to use when storing file metadata. Defaults to "sftpSource".$$ *($$String$$, default: `$$sftpSource$$`)*
+$$sftp.max-fetch$$:: $$The maximum number of remote files to fetch per poll; default unlimited. Does not apply when listing files or building task launch requests.$$ *($$Integer$$, default: `$$<none>$$`)*
 $$sftp.preserve-timestamp$$:: $$Set to true to preserve the original timestamp.$$ *($$Boolean$$, default: `$$true$$`)*
 $$sftp.remote-dir$$:: $$The remote FTP directory.$$ *($$String$$, default: `$$/$$`)*
 $$sftp.remote-file-separator$$:: $$The remote file separator.$$ *($$String$$, default: `$$/$$`)*

--- a/spring-cloud-starter-stream-source-sftp/pom.xml
+++ b/spring-cloud-starter-stream-source-sftp/pom.xml
@@ -17,6 +17,17 @@
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-sftp</artifactId>
+			<version>5.0.7.BUILD-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-file</artifactId>
+			<version>5.0.7.BUILD-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-core</artifactId>
+			<version>5.0.7.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>

--- a/spring-cloud-starter-stream-source-sftp/pom.xml
+++ b/spring-cloud-starter-stream-source-sftp/pom.xml
@@ -17,17 +17,14 @@
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-sftp</artifactId>
-			<version>5.0.7.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-file</artifactId>
-			<version>5.0.7.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-core</artifactId>
-			<version>5.0.7.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/ListFilesRotator.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/ListFilesRotator.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.sftp.source;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.cloud.stream.app.sftp.source.SftpSourceProperties.Factory;
+import org.springframework.cloud.stream.app.sftp.source.SftpSourceSessionFactoryConfiguration.DelegatingFactoryWrapper;
+import org.springframework.cloud.stream.app.sftp.source.tasklauncher.SftpSourceTaskLauncherConfiguration;
+import org.springframework.integration.aop.AbstractMessageSourceAdvice;
+import org.springframework.integration.core.MessageSource;
+import org.springframework.integration.expression.FunctionExpression;
+import org.springframework.integration.file.remote.aop.RotatingServerAdvice.KeyDirectory;
+import org.springframework.integration.file.remote.session.DelegatingSessionFactory;
+import org.springframework.messaging.Message;
+
+/**
+ * An {@link AbstractMessageSourceAdvice} for listing files on multiple
+ * directories/servers.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+class ListFilesRotator extends AbstractMessageSourceAdvice {
+
+	private static final Log logger = LogFactory.getLog(ListFilesRotator.class);
+
+	private final SftpSourceProperties properties;
+
+	private final DelegatingSessionFactory<?> sessionFactory;
+
+	private final List<KeyDirectory> keyDirs = new ArrayList<>();
+
+	private final boolean fair;
+
+	private volatile boolean initialized;
+
+	private volatile Iterator<KeyDirectory> iterator;
+
+	private volatile KeyDirectory current;
+
+	ListFilesRotator(SftpSourceProperties properties, DelegatingFactoryWrapper factory) {
+		this.properties = properties;
+		this.sessionFactory = factory.getFactory();
+		if (properties.isMultiSource()) {
+			this.keyDirs.addAll(SftpSourceProperties.keyDirectories(properties));
+		}
+		this.fair = properties.isFair();
+		this.iterator = this.keyDirs.iterator();
+	}
+
+	public Map<String, Object> headers() {
+		Supplier<Factory> factory = () -> {
+			Factory selected = this.properties.getFactories().get(this.current.getKey());
+			if (selected == null) {
+				// missing key used default factory
+				selected = this.properties.getFactory();
+			}
+			return selected;
+		};
+		Map<String, Object> map = new HashMap<>();
+		map.put(SftpSourceTaskLauncherConfiguration.SFTP_SELECTED_SERVER_PROPERTY_KEY,
+				new FunctionExpression<>(m -> this.current.getKey()));
+		map.put(SftpSourceTaskLauncherConfiguration.SFTP_HOST_PROPERTY_KEY,
+				new FunctionExpression<>(m -> factory.get().getHost()));
+		map.put(SftpSourceTaskLauncherConfiguration.SFTP_PORT_PROPERTY_KEY,
+				new FunctionExpression<>(m -> factory.get().getPort()));
+		map.put(SftpSourceTaskLauncherConfiguration.SFTP_USERNAME_PROPERTY_KEY,
+				new FunctionExpression<>(m -> factory.get().getUsername()));
+		map.put(SftpSourceTaskLauncherConfiguration.SFTP_PASSWORD_PROPERTY_KEY,
+				new FunctionExpression<>(m -> factory.get().getPassword()));
+		return map;
+	}
+
+	public String getCurrentDirectory() {
+		return current.getDirectory();
+	}
+
+	@Override
+	public boolean beforeReceive(MessageSource<?> source) {
+		if (this.fair || !this.initialized) {
+			rotate();
+			this.initialized = true;
+		}
+		if (logger.isTraceEnabled()) {
+			logger.trace("Next poll is for " + this.current);
+		}
+		this.sessionFactory.setThreadKey(this.current.getKey());
+		return true;
+	}
+
+	@Override
+	public Message<?> afterReceive(Message<?> result, MessageSource<?> source) {
+		// We can't reset the key here because the downstream gateway needs it.
+		// The flow must call clearKey after the gateway call.
+		return result;
+	}
+
+	public Message<?> clearKey(Message<List<?>> message) {
+		this.sessionFactory.clearThreadKey();
+		boolean noFilesReceived = message.getPayload().size() == 0;
+		if (logger.isTraceEnabled()) {
+			logger.trace("Poll produced "
+					+ (noFilesReceived ? "no" : "")
+					+ " files");
+		}
+		if (!this.fair && noFilesReceived) {
+			rotate();
+		}
+		return message;
+	}
+
+	private void rotate() {
+		if (!this.iterator.hasNext()) {
+			this.iterator = this.keyDirs.iterator();
+		}
+		this.current = this.iterator.next();
+	}
+
+}

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceConfiguration.java
@@ -15,10 +15,19 @@
 
 package org.springframework.cloud.stream.app.sftp.source;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
-import com.jcraft.jsch.ChannelSftp.LsEntry;
+import org.aopalliance.aop.Advice;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +39,8 @@ import org.springframework.cloud.stream.app.file.FileConsumerProperties;
 import org.springframework.cloud.stream.app.file.FileReadingMode;
 import org.springframework.cloud.stream.app.file.FileUtils;
 import org.springframework.cloud.stream.app.file.remote.RemoteFileDeletingTransactionSynchronizationProcessor;
+import org.springframework.cloud.stream.app.sftp.source.SftpSourceProperties.Factory;
+import org.springframework.cloud.stream.app.sftp.source.SftpSourceProperties.TaskLaunchRequestType;
 import org.springframework.cloud.stream.app.sftp.source.metadata.SftpSourceIdempotentReceiverConfiguration;
 import org.springframework.cloud.stream.app.sftp.source.tasklauncher.SftpSourceTaskLauncherConfiguration;
 import org.springframework.cloud.stream.app.trigger.TriggerConfiguration;
@@ -39,17 +50,22 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.integration.annotation.IdempotentReceiver;
 import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.aop.AbstractMessageSourceAdvice;
 import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlowBuilder;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.SourcePollingChannelAdapterSpec;
+import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.file.FileHeaders;
 import org.springframework.integration.file.filters.ChainFileListFilter;
+import org.springframework.integration.file.remote.aop.RotatingServerAdvice;
+import org.springframework.integration.file.remote.aop.RotatingServerAdvice.KeyDirectory;
 import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway;
+import org.springframework.integration.file.remote.session.DelegatingSessionFactory;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.metadata.ConcurrentMetadataStore;
-import org.springframework.integration.metadata.SimpleMetadataStore;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.integration.sftp.dsl.Sftp;
 import org.springframework.integration.sftp.dsl.SftpInboundChannelAdapterSpec;
@@ -70,6 +86,8 @@ import org.springframework.transaction.interceptor.TransactionInterceptor;
 import org.springframework.util.Assert;
 import org.springframework.util.MimeTypeUtils;
 import org.springframework.util.StringUtils;
+
+import com.jcraft.jsch.ChannelSftp.LsEntry;
 
 /**
  * @author Gary Russell
@@ -103,6 +121,15 @@ public class SftpSourceConfiguration {
 
 	private ConcurrentMetadataStore metadataStore;
 
+	@Autowired(required = false)
+	private ListFilesRotator listFilesRotator;
+
+	@Autowired(required = false)
+	private DelegatingFactoryWrapper delegatingSessionFactory;
+
+	@Autowired(required = false)
+	private RotatingServerAdvice fileSourceRotator;
+
 	@Bean
 	public MessageChannel sftpFileListChannel() {
 		return new DirectChannel();
@@ -113,56 +140,60 @@ public class SftpSourceConfiguration {
 		return new DirectChannel();
 	}
 
+	@SuppressWarnings("resource")
 	@Bean
 	public IntegrationFlow sftpInboundFlow(SessionFactory<LsEntry> sftpSessionFactory,
 			FileConsumerProperties fileConsumerProperties) {
 		ChainFileListFilter<LsEntry> filterChain = new ChainFileListFilter<>();
-		if (StringUtils.hasText(properties.getFilenamePattern())) {
-			filterChain.addFilter(new SftpSimplePatternFileListFilter(properties.getFilenamePattern()));
+		if (StringUtils.hasText(this.properties.getFilenamePattern())) {
+			filterChain.addFilter(new SftpSimplePatternFileListFilter(this.properties.getFilenamePattern()));
 		}
-		else if (properties.getFilenameRegex() != null) {
-			filterChain.addFilter(new SftpRegexPatternFileListFilter(properties.getFilenameRegex()));
+		else if (this.properties.getFilenameRegex() != null) {
+			filterChain.addFilter(new SftpRegexPatternFileListFilter(this.properties.getFilenameRegex()));
 		}
 		filterChain.addFilter(new SftpPersistentAcceptOnceFileListFilter(metadataStore, "sftpSource/"));
 
 		IntegrationFlowBuilder flowBuilder;
 
-		if (properties.isStream()) {
+		if (this.properties.isStream()) {
 			SftpStreamingInboundChannelAdapterSpec messageSourceStreamingSpec =
 					Sftp.inboundStreamingAdapter(this.sftpTemplate)
-							.remoteDirectory(properties.getRemoteDir())
-							.remoteFileSeparator(properties.getRemoteFileSeparator())
+							.remoteDirectory(this.properties.getRemoteDir())
+							.remoteFileSeparator(this.properties.getRemoteFileSeparator())
 							.filter(filterChain);
+			if (this.properties.getMaxFetch() != null) {
+				messageSourceStreamingSpec.maxFetchSize(this.properties.getMaxFetch());
+			}
 
 			flowBuilder = FileUtils.enhanceStreamFlowForReadingMode(
 					IntegrationFlows.from(messageSourceStreamingSpec,
-							properties.isDeleteRemoteFiles() ? consumerSpecWithDelete() : consumerSpec()),
+							this.properties.isDeleteRemoteFiles()
+								? consumerSpecWithDelete(this.fileSourceRotator)
+								: consumerSpec(this.fileSourceRotator)),
 					fileConsumerProperties);
 		}
 		else if (properties.isListOnly() || properties.getTaskLauncherOutput() != SftpSourceProperties
-			.TaskLaunchRequestType.NONE) {
-			return IntegrationFlows.from(() -> properties.getRemoteDir(), consumerSpec())
-					.handle(Sftp.outboundGateway(sftpSessionFactory,
-							AbstractRemoteFileOutboundGateway.Command.LS.getCommand(), "payload")
-							.options(AbstractRemoteFileOutboundGateway.Option.NAME_ONLY.getOption()))
-					.split()
-					.channel(route(properties))
-					.get();
+				.TaskLaunchRequestType.NONE) {
+			return listingFlow(sftpSessionFactory);
 		}
 		else {
 			SftpInboundChannelAdapterSpec messageSourceBuilder =
-					Sftp.inboundAdapter(sftpSessionFactory)
-							.preserveTimestamp(properties.isPreserveTimestamp())
-							.remoteDirectory(properties.getRemoteDir())
-							.remoteFileSeparator(properties.getRemoteFileSeparator())
-							.localDirectory(properties.getLocalDir())
-							.autoCreateLocalDirectory(properties.isAutoCreateLocalDir())
-							.temporaryFileSuffix(properties.getTmpFileSuffix())
-							.deleteRemoteFiles(properties.isDeleteRemoteFiles());
+					Sftp.inboundAdapter(this.properties.isMultiSource()
+								? this.delegatingSessionFactory.getFactory() : sftpSessionFactory)
+							.preserveTimestamp(this.properties.isPreserveTimestamp())
+							.remoteDirectory(this.properties.getRemoteDir())
+							.remoteFileSeparator(this.properties.getRemoteFileSeparator())
+							.localDirectory(this.properties.getLocalDir())
+							.autoCreateLocalDirectory(this.properties.isAutoCreateLocalDir())
+							.temporaryFileSuffix(this.properties.getTmpFileSuffix())
+							.deleteRemoteFiles(this.properties.isDeleteRemoteFiles())
+							.filter(filterChain);
 
-			messageSourceBuilder.filter(filterChain);
+			if (this.properties.getMaxFetch() != null) {
+				messageSourceBuilder.maxFetchSize(this.properties.getMaxFetch());
+			}
 
-			flowBuilder = IntegrationFlows.from(messageSourceBuilder, consumerSpec());
+			flowBuilder = IntegrationFlows.from(messageSourceBuilder, consumerSpec(this.fileSourceRotator));
 
 			if (fileConsumerProperties.getMode() != FileReadingMode.ref) {
 				flowBuilder = FileUtils.enhanceFlowForReadingMode(flowBuilder, fileConsumerProperties);
@@ -174,35 +205,84 @@ public class SftpSourceConfiguration {
 				.get();
 	}
 
-	private MessageChannel route(SftpSourceProperties properties) {
-		return properties.isListOnly() ? sftpFileListChannel() : sftpFileTaskLaunchChannel();
+	private IntegrationFlow listingFlow(SessionFactory<LsEntry> sftpSessionFactory) {
+		if (this.properties.isMultiSource()) {
+			return multiSourceListingFlow();
+		}
+		else {
+			return singleSourceListingFlow(sftpSessionFactory);
+		}
 	}
 
-	private Consumer<SourcePollingChannelAdapterSpec> consumerSpec() {
-		return spec -> spec.poller(SftpSourceConfiguration.this.defaultPoller);
+	private IntegrationFlow singleSourceListingFlow(SessionFactory<LsEntry> sftpSessionFactory) {
+		return IntegrationFlows.from(() -> this.properties.getRemoteDir(), consumerSpec(this.listFilesRotator))
+				.handle(Sftp.outboundGateway(sftpSessionFactory,
+						AbstractRemoteFileOutboundGateway.Command.LS.getCommand(), "payload")
+						.options(AbstractRemoteFileOutboundGateway.Option.NAME_ONLY.getOption()))
+				.split()
+				.channel(listOrLaunchChannel())
+				.get();
 	}
 
-	private Consumer<SourcePollingChannelAdapterSpec> consumerSpecWithDelete() {
+	private IntegrationFlow multiSourceListingFlow() {
+		IntegrationFlowBuilder flow = IntegrationFlows.from(() ->
+					this.listFilesRotator.getCurrentDirectory(), consumerSpec(this.listFilesRotator))
+				.handle(Sftp.outboundGateway(this.delegatingSessionFactory.getFactory(),
+						AbstractRemoteFileOutboundGateway.Command.LS.getCommand(), "payload")
+						.options(AbstractRemoteFileOutboundGateway.Option.NAME_ONLY.getOption()));
+		if (this.properties.getTaskLauncherOutput() != TaskLaunchRequestType.NONE) {
+			flow.enrichHeaders(this.listFilesRotator.headers());
+		}
+		return flow
+				.handle(this.listFilesRotator, "clearKey")
+				.split()
+				.channel(listOrLaunchChannel())
+				.get();
+	}
+
+	private MessageChannel listOrLaunchChannel() {
+		return this.properties.isListOnly() ? sftpFileListChannel() : sftpFileTaskLaunchChannel();
+	}
+
+	private Consumer<SourcePollingChannelAdapterSpec> consumerSpec(Advice advice) {
+		if (advice == null) {
+			return spec -> spec.poller(this.defaultPoller);
+		}
+		else {
+			PollerMetadata poller = new PollerMetadata();
+			BeanUtils.copyProperties(this.defaultPoller, poller, "transactionSynchronizationFactory");
+			poller.setAdviceChain(Arrays.asList(advice));
+			return spec -> spec.poller(poller);
+		}
+	}
+
+	private Consumer<SourcePollingChannelAdapterSpec> consumerSpecWithDelete(Advice advice) {
 		final PollerMetadata poller = new PollerMetadata();
 		BeanUtils.copyProperties(this.defaultPoller, poller, "transactionSynchronizationFactory");
 		TransactionSynchronizationProcessor processor = new RemoteFileDeletingTransactionSynchronizationProcessor(
-				this.sftpTemplate, properties.getRemoteFileSeparator());
+				this.sftpTemplate, this.properties.getRemoteFileSeparator());
 		poller.setTransactionSynchronizationFactory(new DefaultTransactionSynchronizationFactory(processor));
 		poller.setAdviceChain(Collections.singletonList(new TransactionInterceptor(
 				new PseudoTransactionManager(), new MatchAlwaysTransactionAttributeSource())));
+		if (advice != null) {
+			poller.setAdviceChain(Arrays.asList(advice));
+		}
 		return spec -> spec.poller(poller);
 	}
 
 	@Bean
 	@ConditionalOnProperty(name = "sftp.stream")
-	public SftpRemoteFileTemplate sftpTemplate(SessionFactory<LsEntry> sftpSessionFactory) {
-		return new SftpRemoteFileTemplate(sftpSessionFactory);
+	public SftpRemoteFileTemplate sftpTemplate(SessionFactory<LsEntry> sftpSessionFactory,
+			@Autowired(required = false) DelegatingFactoryWrapper wrapper,
+			SftpSourceProperties properties) {
+		return new SftpRemoteFileTemplate(properties.isMultiSource()
+				? wrapper.getFactory() : sftpSessionFactory);
 	}
 
 	@ConditionalOnProperty(name = "sftp.listOnly")
 	@IdempotentReceiver("idempotentReceiverInterceptor")
 	@ServiceActivator(inputChannel = "sftpFileListChannel", outputChannel = Source.OUTPUT)
-	public Message transformSftpMessage(Message message) {
+	public Message<?> transformSftpMessage(Message<?> message) {
 		MessageHeaders messageHeaders = message.getHeaders();
 		Assert.notNull(messageHeaders, "Cannot transform message with null headers");
 		Assert.isTrue(messageHeaders.containsKey(FileHeaders.REMOTE_DIRECTORY), "Remote directory header not found");
@@ -216,6 +296,109 @@ public class SftpSourceConfiguration {
 
 		return MessageBuilder.withPayload(outboundPayload).copyHeaders(messageHeaders)
 				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN).build();
+	}
+
+	@Bean
+	@ConditionalOnProperty("sftp.multi-source")
+	public ListFilesRotator rotator(SftpSourceProperties properties, DelegatingFactoryWrapper factory) {
+		return new ListFilesRotator(properties, factory);
+	}
+
+}
+
+class ListFilesRotator extends AbstractMessageSourceAdvice {
+
+	private static final Log logger = LogFactory.getLog(ListFilesRotator.class);
+
+	private final SftpSourceProperties properties;
+
+	private final DelegatingSessionFactory<?> sessionFactory;
+
+	private final List<KeyDirectory> keyDirs = new ArrayList<>();
+
+	private final boolean fair;
+
+	private volatile boolean initialized;
+
+	private volatile Iterator<KeyDirectory> iterator;
+
+	private volatile KeyDirectory current;
+
+	@Autowired
+	ListFilesRotator(SftpSourceProperties properties, DelegatingFactoryWrapper factory) {
+		this.properties = properties;
+		this.sessionFactory = factory.getFactory();
+		if (properties.isMultiSource()) {
+			this.keyDirs.addAll(SftpSourceProperties.keyDirectories(properties));
+		}
+		this.fair = properties.isFair();
+		this.iterator = this.keyDirs.iterator();
+	}
+
+	public Map<String, Object> headers() {
+		Supplier<Factory> factory = () -> {
+			Factory selected = this.properties.getFactories().get(this.current.getKey());
+			if (selected == null) {
+				// missing key used default factory
+				selected = this.properties.getFactory();
+			}
+			return selected;
+		};
+		Map<String, Object> map = new HashMap<>();
+		map.put(SftpSourceTaskLauncherConfiguration.SFTP_SELECTED_SERVER_PROPERTY_KEY,
+				new FunctionExpression<>(m -> this.current.getKey()));
+		map.put(SftpSourceTaskLauncherConfiguration.SFTP_HOST_PROPERTY_KEY,
+				new FunctionExpression<>(m -> factory.get().getHost()));
+		map.put(SftpSourceTaskLauncherConfiguration.SFTP_PORT_PROPERTY_KEY,
+				new FunctionExpression<>(m -> factory.get().getPort()));
+		map.put(SftpSourceTaskLauncherConfiguration.SFTP_USERNAME_PROPERTY_KEY,
+				new FunctionExpression<>(m -> factory.get().getUsername()));
+		map.put(SftpSourceTaskLauncherConfiguration.SFTP_PASSWORD_PROPERTY_KEY,
+				new FunctionExpression<>(m -> factory.get().getPassword()));
+		return map;
+	}
+
+	public String getCurrentDirectory() {
+		return current.getDirectory();
+	}
+
+	@Override
+	public boolean beforeReceive(MessageSource<?> source) {
+		if (this.fair || !this.initialized) {
+			rotate();
+			this.initialized = true;
+		}
+		if (logger.isTraceEnabled()) {
+			logger.trace("Next poll is for " + this.current);
+		}
+		this.sessionFactory.setThreadKey(this.current.getKey());
+		return true;
+	}
+
+	@Override
+	public Message<?> afterReceive(Message<?> result, MessageSource<?> source) {
+		return result;
+	}
+
+	public Message<?> clearKey(Message<List<?>> message) {
+		this.sessionFactory.clearThreadKey();
+		boolean noFilesReceived = message.getPayload().size() == 0;
+		if (logger.isTraceEnabled()) {
+			logger.trace("Poll produced "
+					+ (noFilesReceived ? "no" : "")
+					+ " files");
+		}
+		if (!this.fair && noFilesReceived) {
+			rotate();
+		}
+		return message;
+	}
+
+	private void rotate() {
+		if (!this.iterator.hasNext()) {
+			this.iterator = this.keyDirs.iterator();
+		}
+		this.current = this.iterator.next();
 	}
 
 }

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceProperties.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceProperties.java
@@ -117,11 +117,6 @@ public class SftpSourceProperties {
 	private Integer maxFetch;
 
 	/**
-	 * True to allow polling multiple servers/directories.
-	 */
-	private boolean multiSource;
-
-	/**
 	 * True for fair polling of multiple servers/directories.
 	 */
 	private boolean fair;
@@ -259,11 +254,7 @@ public class SftpSourceProperties {
 	}
 
 	public boolean isMultiSource() {
-		return this.multiSource;
-	}
-
-	public void setMultiSource(boolean multiSource) {
-		this.multiSource = multiSource;
+		return this.directories != null && this.directories.length > 0;
 	}
 
 	public boolean isFair() {

--- a/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceIntegrationTests.java
+++ b/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceIntegrationTests.java
@@ -261,7 +261,7 @@ public abstract class SftpSourceIntegrationTests extends SftpTestSupport {
 			"sftp.factories.two.cache-sessions = true",
 			"sftp.factories.two.allowUnknownKeys = true",
 			"sftp.directories=one.sftpSource,two.sftpSecondSource,junk.sftpSource",
-			"sftp.max-fetch=3", // TODO fix SI to not include . and .. and sub dirs in fetch count
+			"sftp.max-fetch=1",
 			"sftp.fair=true"
 	})
 	public static class MultiSourceRefTests extends SftpSourceIntegrationTests {
@@ -278,7 +278,7 @@ public abstract class SftpSourceIntegrationTests extends SftpTestSupport {
 		@Test
 		public void sourceFilesAsRef() throws Exception {
 			BlockingQueue<Message<?>> messages = this.messageCollector.forChannel(this.sftpSource.output());
-			int [] expectedOrder = new int[] { 0, 1, 3, 2 }; // max fetch effectively 1
+			int [] expectedOrder = new int[] { 0, 1, 3, 2 }; // max fetch 1
 			for (int i = 1; i <= 3; i++) {
 				Message<?> received = messages.poll(10, TimeUnit.SECONDS);
 				assertNotNull(received);
@@ -310,7 +310,7 @@ public abstract class SftpSourceIntegrationTests extends SftpTestSupport {
 			"sftp.factories.two.cache-sessions = true",
 			"sftp.factories.two.allowUnknownKeys = true",
 			"sftp.directories=one.sftpSource,two.sftpSecondSource,junk.sftpSource",
-			"sftp.max-fetch=3", // TODO fix SI to not include . and .. and sub dirs in fetch count
+			"sftp.max-fetch=1",
 			"sftp.fair=true"
 		})
 	public static class MultiSourceStreamTests extends SftpSourceIntegrationTests {
@@ -328,7 +328,7 @@ public abstract class SftpSourceIntegrationTests extends SftpTestSupport {
 		public void streamSourceFilesAsContents() throws InterruptedException {
 			assertEquals(1,
 					TestUtils.getPropertyValue(this.sourcePollingChannelAdapter, "adviceChain", List.class).size());
-			int [] expectedOrder = new int[] { 0, 1, 3, 2 }; // max fetch effectively 1
+			int [] expectedOrder = new int[] { 0, 1, 3, 2 }; // max fetch 1
 			for (int i = 1; i <= 3; i++) {
 				@SuppressWarnings("unchecked")
 				Message<byte[]> received = (Message<byte[]>) this.messageCollector.forChannel(sftpSource.output())

--- a/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherIntegrationTests.java
+++ b/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherIntegrationTests.java
@@ -79,7 +79,7 @@ public abstract class SftpSourceTaskLauncherIntegrationTests extends SftpTestSup
 		@Test
 		public void pollAndAssertFiles() throws Exception {
 			for (int i = 1; i <= 2; i++) {
-				@SuppressWarnings("unchecked") Message<?> received = this.messageCollector.forChannel(
+				Message<?> received = this.messageCollector.forChannel(
 					this.sftpSource.output()).poll(10, TimeUnit.SECONDS);
 
 				assertNotNull("No files were received", received);
@@ -147,7 +147,7 @@ public abstract class SftpSourceTaskLauncherIntegrationTests extends SftpTestSup
 		public void outputIsCorrect() throws Exception {
 
 			for (int i = 1; i <= 2; i++) {
-				@SuppressWarnings("unchecked") Message<?> received = this.messageCollector.forChannel(
+				Message<?> received = this.messageCollector.forChannel(
 					this.sftpSource.output()).poll(10, TimeUnit.SECONDS);
 
 				assertNotNull("No files were received", received);
@@ -177,7 +177,6 @@ public abstract class SftpSourceTaskLauncherIntegrationTests extends SftpTestSup
 			"sftp.factory.username = user",
 			"sftp.factory.password = pass",
 			"sftp.metadata.redis.keyName = sftpSourceTest",
-			"sftp.multi-source = true",
 			"sftp.factories.one.host=localhost",
 			"sftp.factories.one.port=${sftp.factory.port}",
 			"sftp.factories.one.username = user",
@@ -207,7 +206,6 @@ public abstract class SftpSourceTaskLauncherIntegrationTests extends SftpTestSup
 		@Test
 		public void pollAndAssertFiles() throws Exception {
 			for (int i = 1; i <= 3; i++) {
-				@SuppressWarnings("unchecked")
 				Message<?> received = this.messageCollector.forChannel(this.sftpSource.output()).poll(10, TimeUnit.SECONDS);
 
 				assertNotNull((i - 1) + " files were received, expected 3", received);

--- a/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherIntegrationTests.java
+++ b/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherIntegrationTests.java
@@ -167,16 +167,15 @@ public abstract class SftpSourceTaskLauncherIntegrationTests extends SftpTestSup
 	}
 
 	@TestPropertySource(properties = {
-			"sftp.taskLauncherOutput = true",
-			"sftp.batch.batchResourceUri = file://some.jar",
-			"sftp.batch.dataSourceUserName = sa",
-			"sftp.batch.dataSourceUrl = jdbc://host:2222/mem",
-			"sftp.batch.localFilePathJobParameterValue = /tmp/files/",
-			"sftp.batch.jobParameters = jpk1=jpv1,jpk2=jpv2",
+			"sftp.taskLauncherOutput = STANDALONE",
+			"sftp.task.resourceUri = file://some.jar",
+			"sftp.task.dataSourceUserName = sa",
+			"sftp.task.dataSourceUrl = jdbc://host:2222/mem",
+			"sftp.task.localFilePathParameterValue = /tmp/files/",
+			"sftp.task.parameters = jpk1=jpv1,jpk2=jpv2",
 			"sftp.factory.host = 127.0.0.1",
 			"sftp.factory.username = user",
 			"sftp.factory.password = pass",
-			"sftp.metadata.redis.keyName = sftpSourceTest",
 			"sftp.factories.one.host=localhost",
 			"sftp.factories.one.port=${sftp.factory.port}",
 			"sftp.factories.one.username = user",

--- a/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherIntegrationTests.java
+++ b/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherIntegrationTests.java
@@ -15,12 +15,19 @@
 
 package org.springframework.cloud.stream.app.sftp.source.tasklauncher;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.FileOutputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.assertj.core.api.Assertions;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -39,15 +46,13 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.MimeTypeUtils;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 
 /**
  * @author Chris Schaefer
  * @author David Turanski
+ * @author Gary Russell
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = { "sftp.remoteDir = sftpSource",
@@ -160,4 +165,96 @@ public abstract class SftpSourceTaskLauncherIntegrationTests extends SftpTestSup
 			}
 		}
 	}
+
+	@TestPropertySource(properties = {
+			"sftp.taskLauncherOutput = true",
+			"sftp.batch.batchResourceUri = file://some.jar",
+			"sftp.batch.dataSourceUserName = sa",
+			"sftp.batch.dataSourceUrl = jdbc://host:2222/mem",
+			"sftp.batch.localFilePathJobParameterValue = /tmp/files/",
+			"sftp.batch.jobParameters = jpk1=jpv1,jpk2=jpv2",
+			"sftp.factory.host = 127.0.0.1",
+			"sftp.factory.username = user",
+			"sftp.factory.password = pass",
+			"sftp.metadata.redis.keyName = sftpSourceTest",
+			"sftp.multi-source = true",
+			"sftp.factories.one.host=localhost",
+			"sftp.factories.one.port=${sftp.factory.port}",
+			"sftp.factories.one.username = user",
+			"sftp.factories.one.password = pass",
+			"sftp.factories.one.cache-sessions = true",
+			"sftp.factories.one.allowUnknownKeys = true",
+			"sftp.factories.two.host=localhost",
+			"sftp.factories.two.port=${sftp.factory.port}",
+			"sftp.factories.two.username = user",
+			"sftp.factories.two.password = pass",
+			"sftp.factories.two.cache-sessions = true",
+			"sftp.factories.two.allowUnknownKeys = true",
+			"sftp.directories=one.sftpSource,two.sftpSecondSource,junk.sftpSource",
+			"sftp.fair=true"
+	})
+	public static class TaskLauncherOutputMultiSourceTests extends SftpSourceTaskLauncherIntegrationTests {
+
+		@BeforeClass
+		public static void setup() throws Exception {
+			File secondFolder = remoteTemporaryFolder.newFolder("sftpSecondSource");
+			File file = new File(secondFolder, "sftpSource3.txt");
+			FileOutputStream fos = new FileOutputStream(file);
+			fos.write("source3".getBytes());
+			fos.close();
+		}
+
+		@Test
+		public void pollAndAssertFiles() throws Exception {
+			for (int i = 1; i <= 3; i++) {
+				@SuppressWarnings("unchecked")
+				Message<?> received = this.messageCollector.forChannel(this.sftpSource.output()).poll(10, TimeUnit.SECONDS);
+
+				assertNotNull((i - 1) + " files were received, expected 3", received);
+				assertThat(received.getPayload(), instanceOf(String.class));
+
+				assertEquals(MimeTypeUtils.APPLICATION_JSON, received.getHeaders().get(MessageHeaders.CONTENT_TYPE));
+				TaskLaunchRequest taskLaunchRequest = new ObjectMapper().readValue((String) received.getPayload(), TaskLaunchRequest.class);
+				assertNotNull(taskLaunchRequest);
+
+				assertEquals("Unexpected number of deployment properties", 0,
+						taskLaunchRequest.getDeploymentProperties().size());
+				assertEquals("Unexpected batch artifact URI", "file://some.jar", taskLaunchRequest.getUri());
+
+				Map<String, String> environmentProperties = taskLaunchRequest.getEnvironmentProperties();
+				assertEquals("Unexpected datasource user name", "sa",
+						environmentProperties.get(SftpSourceTaskLauncherConfiguration.DATASOURCE_USERNAME_PROPERTY_KEY));
+				assertEquals("Unexpected datasource url", "jdbc://host:2222/mem",
+						environmentProperties.get(SftpSourceTaskLauncherConfiguration.DATASOURCE_URL_PROPERTY_KEY));
+				assertEquals("Unexpected SFTP host", "localhost",
+						environmentProperties.get(SftpSourceTaskLauncherConfiguration.SFTP_HOST_PROPERTY_KEY));
+				assertEquals("Unexpected SFTP username", "user",
+						environmentProperties.get(SftpSourceTaskLauncherConfiguration.SFTP_USERNAME_PROPERTY_KEY));
+				assertEquals("Unexpected SFTP password", "pass",
+						environmentProperties.get(SftpSourceTaskLauncherConfiguration.SFTP_PASSWORD_PROPERTY_KEY));
+				assertNotNull("SFTP port is null",
+						environmentProperties.get(SftpSourceTaskLauncherConfiguration.SFTP_PORT_PROPERTY_KEY));
+				assertEquals("Unexpected selected server", i < 3 ? "one" : "two",
+						environmentProperties
+								.get(SftpSourceTaskLauncherConfiguration.SFTP_SELECTED_SERVER_PROPERTY_KEY));
+
+				List<String> commandlineArguments = taskLaunchRequest.getCommandlineArguments();
+				assertEquals("Unexpected number of commandline arguments", 4, commandlineArguments.size());
+				assertEquals("Unexpected remote file path", "remoteFilePath=sftp"
+						+ (i == 3 ? "Second" : "")
+						+ "Source/sftpSource" + i + ".txt",
+						commandlineArguments.get(0));
+				assertEquals("Unexpected local file path", "localFilePath=/tmp/files/sftpSource" + i + ".txt",
+						commandlineArguments.get(1));
+				assertEquals("Unexpected job parameter", "jpk1=jpv1", commandlineArguments.get(2));
+				assertEquals("Unexpected job parameter", "jpk2=jpv2", commandlineArguments.get(3));
+			}
+
+			assertNotNull(this.metadataStore.get("sftpSource/sftpSource1.txt"));
+			assertNotNull(this.metadataStore.get("sftpSource/sftpSource2.txt"));
+			assertNotNull(this.metadataStore.get("sftpSecondSource/sftpSource3.txt"));
+		}
+
+	}
+
 }


### PR DESCRIPTION
Resolves https://github.com/spring-cloud-stream-app-starters/sftp/issues/12

Add support for multiple session factories, wrapped in a `DelegatingSessionFactory`.

Apply the `RotatingServerAdice` to the inbound channel adapters.

For `listOnly` and `taskLauncherOutput` use a custom advice since the channel adapters
are not used there.
In this case defer the rotation until after extracing the environment variables for the
task launch request.