### PR TITLE
Add Support for Data Flow Task Launcher Sink

### DIFF
--- a/spring-cloud-starter-stream-source-sftp/README.adoc
+++ b/spring-cloud-starter-stream-source-sftp/README.adoc
@@ -81,6 +81,7 @@ $$file.consumer.mode$$:: $$The FileReadingMode to use for file reading sources.
 $$file.consumer.with-markers$$:: $$Set to true to emit start of file/end of file marker messages before/after the data.
  	Only valid with FileReadingMode 'lines'.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$sftp.auto-create-local-dir$$:: $$Set to true to create the local directory if it does not exist.$$ *($$Boolean$$, default: `$$true$$`)*
+$$sftp.batch.application-name$$:: $$The task application name (required for DATAFLOW launch request).$$ *($$String$$, default: `$$<none>$$`)*
 $$sftp.batch.batch-resource-uri$$:: $$The URI of the batch artifact to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<empty string>$$`)*
 $$sftp.batch.data-source-password$$:: $$The datasource password to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
 $$sftp.batch.data-source-url$$:: $$The datasource url to be applied to the TaskLaunchRequest. Defaults to h2 in-memory
@@ -112,7 +113,7 @@ $$sftp.preserve-timestamp$$:: $$Set to true to preserve the original timestamp.$
 $$sftp.remote-dir$$:: $$The remote FTP directory.$$ *($$String$$, default: `$$/$$`)*
 $$sftp.remote-file-separator$$:: $$The remote file separator.$$ *($$String$$, default: `$$/$$`)*
 $$sftp.stream$$:: $$Set to true to stream the file rather than copy to a local directory.$$ *($$Boolean$$, default: `$$false$$`)*
-$$sftp.task-launcher-output$$:: $$Set to true to create output suitable for a task launch request.$$ *($$Boolean$$, default: `$$false$$`)*
+$$sftp.task-launcher-output$$:: $$Set to create output suitable for a task launch request. Default is `NONE`$$ *($$TaskLaunchRequestType$$, default: `$$<none>$$`, possible values: `DATAFLOW`,`STANDALONE`,`NONE`)*
 $$sftp.tmp-file-suffix$$:: $$The suffix to use while the transfer is in progress.$$ *($$String$$, default: `$$.tmp$$`)*
 $$trigger.cron$$:: $$Cron expression value for the Cron Trigger.$$ *($$String$$, default: `$$<none>$$`)*
 $$trigger.date-format$$:: $$Format for the date value.$$ *($$String$$, default: `$$<none>$$`)*

--- a/spring-cloud-starter-stream-source-sftp/README.adoc
+++ b/spring-cloud-starter-stream-source-sftp/README.adoc
@@ -77,15 +77,15 @@ A `java.io.File` object.
 ==== Payload:
 
 A https://docs.spring.io/spring-cloud-task/docs/current/apidocs/org/springframework/cloud/task/launcher/TaskLaunchRequest.html[TaskLaunchRequest] object.
-with the following set as command line arguments (job parameters):
+with the following set as command line arguments (also bound to job parameters for Spring Batch):
 
-* `<local-file-path-job-parameter-name>`=`<local-file-path-job-parameter-value>`
-* `<remote-file-path-job-parameter-name>`=`<remote-file-path-job-parameter-value>`
-*  Any provided`job-parameters`
+* `<task.local-file-path-parameter-name>`=`<task.local-file-path-parameter-value>`
+* `<task.remote-file-path-parameter-name>`=`<task.remote-file-path-parameter-value>`
+*  Any provided`task.parameters`
 
-`batch-resource-uri` is required.
-`batch-deployment-properties` and `batch-environment-properties` are optional.
-`batch-application-name` is ignored and will be generated.
+`task.resource-uri` is required.
+`task.deployment-properties` and `task.environment-properties` are optional.
+`task.application-name` is ignored and will be generated.
 
 === task-launcher-output = DATAFLOW
 
@@ -96,47 +96,28 @@ with the following set as command line arguments (job parameters):
 
 ==== Payload:
 
-A DataFlow Task Launch request as JSON: `{"name":"<batch-application-name>", "deploymentProps":{"key"="val",...},
+A DataFlow Task Launch request as JSON: `{"name":"<task.application-name>", "deploymentProps":{"key"="val",...},
 "args":[]}`
-with the following set as command line arguments (job parameters):
+with the following set as command line arguments (also bound to job parameters for Spring Batch):
 
-* `<local-file-path-job-parameter-name>`=`<local-file-path-job-parameter-value>`
-* `<remote-file-path-job-parameter-name>`=`<remote-file-path-job-parameter-value>`
-*  Any provided`job-parameters`
+* `<task.local-file-path-parameter-name>`=`<task.local-file-path-parameter-value>`
+* `<task.remote-file-path-parameter-name>`=`<task.remote-file-path-parameter-value>`
+*  Any provided`task.parameters`
 
-`batch-resource-uri` is ignored (already registered in Data Flow Server).
-``batch-environment-properties` is ignored (configured is Data Flow Server).
-`batch-deployment-properties` is optional.
-`batch-application-name` is required (the Data Flow Task Name).
+`task.resource-uri` is ignored (already registered in Data Flow Server).
+`task.environment-properties` is ignored (configured is Data Flow Server).
+`task.deployment-properties` is optional.
+`task.application-name` is required (the Data Flow Task Name).
 
 == Options
 
 The **$$sftp$$** $$source$$ has the following options:
 
 //tag::configuration-properties[]
-$$file.consumer.markers-json$$:: $$When 'fileMarkers == true', specify if they should be produced
- as FileSplitter.FileMarker objects or JSON.$$ *($$Boolean$$, default: `$$true$$`)*
-$$file.consumer.mode$$:: $$The FileReadingMode to use for file reading sources.
- Values are 'ref' - The File object,
- 'lines' - a message per line, or
- 'contents' - the contents as bytes.$$ *($$FileReadingMode$$, default: `$$<none>$$`, possible values: `ref`,`lines`,`contents`)*
-$$file.consumer.with-markers$$:: $$Set to true to emit start of file/end of file marker messages before/after the data.
- 	Only valid with FileReadingMode 'lines'.$$ *($$Boolean$$, default: `$$<none>$$`)*
+$$file.consumer.markers-json$$:: $$When 'fileMarkers == true', specify if they should be produced as FileSplitter.FileMarker objects or JSON.$$ *($$Boolean$$, default: `$$true$$`)*
+$$file.consumer.mode$$:: $$The FileReadingMode to use for file reading sources. Values are 'ref' - The File object, 'lines' - a message per line, or 'contents' - the contents as bytes.$$ *($$FileReadingMode$$, default: `$$<none>$$`, possible values: `ref`,`lines`,`contents`)*
+$$file.consumer.with-markers$$:: $$Set to true to emit start of file/end of file marker messages before/after the data. 	Only valid with FileReadingMode 'lines'.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$sftp.auto-create-local-dir$$:: $$Set to true to create the local directory if it does not exist.$$ *($$Boolean$$, default: `$$true$$`)*
-$$sftp.batch.application-name$$:: $$The task application name (required for DATAFLOW launch request).$$ *($$String$$, default: `$$<none>$$`)*
-$$sftp.batch.batch-resource-uri$$:: $$The URI of the batch artifact to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<empty string>$$`)*
-$$sftp.batch.data-source-password$$:: $$The datasource password to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
-$$sftp.batch.data-source-url$$:: $$The datasource url to be applied to the TaskLaunchRequest. Defaults to h2 in-memory
- JDBC datasource url.$$ *($$String$$, default: `$$jdbc:h2:tcp://localhost:19092/mem:dataflow$$`)*
-$$sftp.batch.data-source-user-name$$:: $$The datasource user name to be applied to the TaskLaunchRequest. Defaults to "sa"$$ *($$String$$, default: `$$sa$$`)*
-$$sftp.batch.deployment-properties$$:: $$Comma delimited list of deployment properties to be applied to the
- TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
-$$sftp.batch.environment-properties$$:: $$Comma delimited list of environment properties to be applied to the
- TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
-$$sftp.batch.job-parameters$$:: $$Comma separated list of optional job parameters in key=value format.$$ *($$List<String>$$, default: `$$<none>$$`)*
-$$sftp.batch.local-file-path-job-parameter-name$$:: $$Value to use as the local file job parameter name. Defaults to "localFilePath".$$ *($$String$$, default: `$$localFilePath$$`)*
-$$sftp.batch.local-file-path-job-parameter-value$$:: $$The file path to use as the local file job parameter value. Defaults to "java.io.tmpdir".$$ *($$String$$, default: `$$<none>$$`)*
-$$sftp.batch.remote-file-path-job-parameter-name$$:: $$Value to use as the remote file job parameter name. Defaults to "remoteFilePath".$$ *($$String$$, default: `$$remoteFilePath$$`)*
 $$sftp.delete-remote-files$$:: $$Set to true to delete remote files after successful transfer.$$ *($$Boolean$$, default: `$$false$$`)*
 $$sftp.factory.allow-unknown-keys$$:: $$True to allow an unknown or changed key.$$ *($$Boolean$$, default: `$$false$$`)*
 $$sftp.factory.cache-sessions$$:: $$Cache sessions$$ *($$Boolean$$, default: `$$<none>$$`)*
@@ -156,6 +137,17 @@ $$sftp.remote-dir$$:: $$The remote FTP directory.$$ *($$String$$, default: `$$/$
 $$sftp.remote-file-separator$$:: $$The remote file separator.$$ *($$String$$, default: `$$/$$`)*
 $$sftp.stream$$:: $$Set to true to stream the file rather than copy to a local directory.$$ *($$Boolean$$, default: `$$false$$`)*
 $$sftp.task-launcher-output$$:: $$Set to create output suitable for a task launch request. Default is `NONE`$$ *($$TaskLaunchRequestType$$, default: `$$<none>$$`, possible values: `DATAFLOW`,`STANDALONE`,`NONE`)*
+$$sftp.task.application-name$$:: $$The task application name (required for DATAFLOW launch request).$$ *($$String$$, default: `$$<none>$$`)*
+$$sftp.task.data-source-password$$:: $$The datasource password to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
+$$sftp.task.data-source-url$$:: $$The datasource url to be applied to the TaskLaunchRequest. Defaults to h2 in-memory JDBC datasource url.$$ *($$String$$, default: `$$jdbc:h2:tcp://localhost:19092/mem:dataflow$$`)*
+$$sftp.task.data-source-user-name$$:: $$The datasource user name to be applied to the TaskLaunchRequest. Defaults to "sa"$$ *($$String$$, default: `$$sa$$`)*
+$$sftp.task.deployment-properties$$:: $$Comma delimited list of deployment properties to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
+$$sftp.task.environment-properties$$:: $$Comma delimited list of environment properties to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
+$$sftp.task.local-file-path-parameter-name$$:: $$Value to use as the local file parameter name.$$ *($$String$$, default: `$$localFilePath$$`)*
+$$sftp.task.local-file-path-parameter-value$$:: $$The file path to use as the local file parameter value. Defaults to "java.io.tmpdir".$$ *($$String$$, default: `$$<none>$$`)*
+$$sftp.task.parameters$$:: $$Comma separated list of optional parameters in key=value format.$$ *($$List<String>$$, default: `$$<none>$$`)*
+$$sftp.task.remote-file-path-parameter-name$$:: $$Value to use as the remote file parameter name.$$ *($$String$$, default: `$$remoteFilePath$$`)*
+$$sftp.task.resource-uri$$:: $$The URI of the task artifact to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<empty string>$$`)*
 $$sftp.tmp-file-suffix$$:: $$The suffix to use while the transfer is in progress.$$ *($$String$$, default: `$$.tmp$$`)*
 $$trigger.cron$$:: $$Cron expression value for the Cron Trigger.$$ *($$String$$, default: `$$<none>$$`)*
 $$trigger.date-format$$:: $$Format for the date value.$$ *($$String$$, default: `$$<none>$$`)*

--- a/spring-cloud-starter-stream-source-sftp/README.adoc
+++ b/spring-cloud-starter-stream-source-sftp/README.adoc
@@ -67,6 +67,48 @@ None.
 
 A `java.io.File` object.
 
+=== task-launcher-output = STANDALONE
+
+==== Headers:
+
+* `Content-Type: application/json`
+* `file_remoteDirectory: <java.lang.String>`
+
+==== Payload:
+
+A https://docs.spring.io/spring-cloud-task/docs/current/apidocs/org/springframework/cloud/task/launcher/TaskLaunchRequest.html[TaskLaunchRequest] object.
+with the following set as command line arguments (job parameters):
+
+* `<local-file-path-job-parameter-name>`=`<local-file-path-job-parameter-value>`
+* `<remote-file-path-job-parameter-name>`=`<remote-file-path-job-parameter-value>`
+*  Any provided`job-parameters`
+
+`batch-resource-uri` is required.
+`batch-deployment-properties` and `batch-environment-properties` are optional.
+`batch-application-name` is ignored and will be generated.
+
+=== task-launcher-output = DATAFLOW
+
+==== Headers:
+
+* `Content-Type: application/json`
+* `file_remoteDirectory: <java.lang.String>`
+
+==== Payload:
+
+A DataFlow Task Launch request as JSON: `{"name":"<batch-application-name>", "deploymentProps":{"key"="val",...},
+"args":[]}`
+with the following set as command line arguments (job parameters):
+
+* `<local-file-path-job-parameter-name>`=`<local-file-path-job-parameter-value>`
+* `<remote-file-path-job-parameter-name>`=`<remote-file-path-job-parameter-value>`
+*  Any provided`job-parameters`
+
+`batch-resource-uri` is ignored (already registered in Data Flow Server).
+``batch-environment-properties` is ignored (configured is Data Flow Server).
+`batch-deployment-properties` is optional.
+`batch-application-name` is required (the Data Flow Task Name).
+
 == Options
 
 The **$$sftp$$** $$source$$ has the following options:

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceProperties.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceProperties.java
@@ -33,10 +33,12 @@ import org.springframework.validation.annotation.Validated;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Chris Schaefer
+ * @author David Turanski
  */
 @ConfigurationProperties("sftp")
 @Validated
 public class SftpSourceProperties {
+	public enum TaskLaunchRequestType {DATAFLOW, STANDALONE, NONE};
 
 	/**
 	 * Session factory properties.
@@ -99,9 +101,9 @@ public class SftpSourceProperties {
 	private boolean listOnly = false;
 
 	/**
-	 * Set to true to create output suitable for a task launch request.
+	 * Set to create output suitable for a task launch request. Default is `NONE`
 	 */
-	private boolean taskLauncherOutput = false;
+	private TaskLaunchRequestType taskLauncherOutput = TaskLaunchRequestType.NONE;
 
 	@NotBlank
 	public String getRemoteDir() {
@@ -186,7 +188,7 @@ public class SftpSourceProperties {
 
 	@AssertFalse(message = "listOnly and taskLauncherOutput cannot be used at the same time")
 	public boolean isListOnlyOrTaskLauncher() {
-		return listOnly && taskLauncherOutput;
+		return listOnly && taskLauncherOutput != TaskLaunchRequestType.NONE;
 	}
 
 	public boolean isStream() {
@@ -201,11 +203,11 @@ public class SftpSourceProperties {
 		return this.factory;
 	}
 
-	public boolean isTaskLauncherOutput() {
+	public TaskLaunchRequestType getTaskLauncherOutput() {
 		return taskLauncherOutput;
 	}
 
-	public void setTaskLauncherOutput(boolean taskLauncherOutput) {
+	public void setTaskLauncherOutput(TaskLaunchRequestType taskLauncherOutput) {
 		this.taskLauncherOutput = taskLauncherOutput;
 	}
 

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/batch/SftpSourceBatchProperties.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/batch/SftpSourceBatchProperties.java
@@ -89,6 +89,13 @@ public class SftpSourceBatchProperties {
 	 */
 	private List<String> jobParameters = new ArrayList<>();
 
+	/**
+	 *
+	 * The task application name (required for DATAFLOW launch request).
+	 */
+	private String applicationName;
+
+
 	@NotNull
 	public String getBatchResourceUri() {
 		return this.batchResourceUri;
@@ -173,4 +180,11 @@ public class SftpSourceBatchProperties {
 		this.jobParameters = jobParameters;
 	}
 
+	public String getApplicationName() {
+		return applicationName;
+	}
+
+	public void setApplicationName(String applicationName) {
+		this.applicationName = applicationName;
+	}
 }

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/task/SftpSourceTaskProperties.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/task/SftpSourceTaskProperties.java
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.stream.app.sftp.source.batch;
+package org.springframework.cloud.stream.app.sftp.source.task;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -27,19 +27,20 @@ import org.springframework.validation.annotation.Validated;
 
 /**
  * @author Chris Schaefer
+ * @author David Turanski
  */
 @Validated
-@ConfigurationProperties("sftp.batch")
-public class SftpSourceBatchProperties {
+@ConfigurationProperties("sftp.task")
+public class SftpSourceTaskProperties {
 
-	protected static final String DEFAULT_LOCAL_FILE_PATH_JOB_PARAM_NAME = "localFilePath";
+	protected static final String DEFAULT_LOCAL_FILE_PATH_PARAM_NAME = "localFilePath";
 
-	protected static final String DEFAULT_REMOTE_FILE_PATH_JOB_PARAM_NAME = "remoteFilePath";
+	protected static final String DEFAULT_REMOTE_FILE_PATH_PARAM_NAME = "remoteFilePath";
 
 	/**
-	 * The URI of the batch artifact to be applied to the TaskLaunchRequest.
+	 * The URI of the task artifact to be applied to the TaskLaunchRequest.
 	 */
-	private String batchResourceUri = "";
+	private String resourceUri = "";
 
 	/**
 	 * The datasource url to be applied to the TaskLaunchRequest. Defaults to h2 in-memory
@@ -70,24 +71,24 @@ public class SftpSourceBatchProperties {
 	private String environmentProperties;
 
 	/**
-	 * Value to use as the remote file job parameter name. Defaults to "remoteFilePath".
+	 * Value to use as the remote file parameter name.
 	 */
-	private String remoteFilePathJobParameterName = DEFAULT_REMOTE_FILE_PATH_JOB_PARAM_NAME;
+	private String remoteFilePathParameterName = DEFAULT_REMOTE_FILE_PATH_PARAM_NAME;
 
 	/**
-	 * Value to use as the local file job parameter name. Defaults to "localFilePath".
+	 * Value to use as the local file parameter name.
 	 */
-	private String localFilePathJobParameterName = DEFAULT_LOCAL_FILE_PATH_JOB_PARAM_NAME;
+	private String localFilePathParameterName = DEFAULT_LOCAL_FILE_PATH_PARAM_NAME;
 
 	/**
-	 * The file path to use as the local file job parameter value. Defaults to "java.io.tmpdir".
+	 * The file path to use as the local file parameter value. Defaults to "java.io.tmpdir".
 	 */
-	private String localFilePathJobParameterValue = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
+	private String localFilePathParameterValue = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
 
 	/**
-	 * Comma separated list of optional job parameters in key=value format.
+	 * Comma separated list of optional parameters in key=value format.
 	 */
-	private List<String> jobParameters = new ArrayList<>();
+	private List<String> parameters = new ArrayList<>();
 
 	/**
 	 *
@@ -97,12 +98,12 @@ public class SftpSourceBatchProperties {
 
 
 	@NotNull
-	public String getBatchResourceUri() {
-		return this.batchResourceUri;
+	public String getResourceUri() {
+		return this.resourceUri;
 	}
 
-	public void setBatchResourceUri(String batchResourceUri) {
-		this.batchResourceUri = batchResourceUri;
+	public void setResourceUri(String resourceUri) {
+		this.resourceUri = resourceUri;
 	}
 
 	@NotBlank
@@ -147,37 +148,37 @@ public class SftpSourceBatchProperties {
 		this.environmentProperties = environmentProperties;
 	}
 
-	public String getRemoteFilePathJobParameterName() {
-		return this.remoteFilePathJobParameterName;
+	public String getRemoteFilePathParameterName() {
+		return this.remoteFilePathParameterName;
 	}
 
-	public void setRemoteFilePathJobParameterName(String remoteFilePathJobParameterName) {
-		this.remoteFilePathJobParameterName = remoteFilePathJobParameterName;
+	public void setRemoteFilePathParameterName(String remoteFilePathParameterName) {
+		this.remoteFilePathParameterName = remoteFilePathParameterName;
 	}
 
-	public String getLocalFilePathJobParameterName() {
-		return this.localFilePathJobParameterName;
+	public String getLocalFilePathParameterName() {
+		return this.localFilePathParameterName;
 	}
 
-	public void setLocalFilePathJobParameterName(String localFilePathJobParameterName) {
-		this.localFilePathJobParameterName = localFilePathJobParameterName;
+	public void setLocalFilePathParameterName(String localFilePathParameterName) {
+		this.localFilePathParameterName = localFilePathParameterName;
 	}
 
 	@NotBlank
-	public String getLocalFilePathJobParameterValue() {
-		return this.localFilePathJobParameterValue;
+	public String getLocalFilePathParameterValue() {
+		return this.localFilePathParameterValue;
 	}
 
-	public void setLocalFilePathJobParameterValue(String localFilePathJobParameterValue) {
-		this.localFilePathJobParameterValue = localFilePathJobParameterValue;
+	public void setLocalFilePathParameterValue(String localFilePathParameterValue) {
+		this.localFilePathParameterValue = localFilePathParameterValue;
 	}
 
-	public List<String> getJobParameters() {
-		return this.jobParameters;
+	public List<String> getParameters() {
+		return this.parameters;
 	}
 
-	public void setJobParameters(List<String> jobParameters) {
-		this.jobParameters = jobParameters;
+	public void setParameters(List<String> parameters) {
+		this.parameters = parameters;
 	}
 
 	public String getApplicationName() {

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherConfiguration.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherConfiguration.java
@@ -66,6 +66,8 @@ public class SftpSourceTaskLauncherConfiguration {
 
 	protected static final String DATASOURCE_USERNAME_PROPERTY_KEY = "spring.datasource.username";
 
+	protected static final String DATASOURCE_PASSWORD_PROPERTY_KEY = "spring.datasource.password";
+
 	private SftpSourceProperties sftpSourceProperties;
 
 	private SftpSourceTaskProperties sftpSourceTaskProperties;
@@ -85,7 +87,7 @@ public class SftpSourceTaskLauncherConfiguration {
 	@ConditionalOnProperty(name = "sftp.task-launcher-output", havingValue = "STANDALONE")
 	@IdempotentReceiver("idempotentReceiverInterceptor")
 	@ServiceActivator(inputChannel = "sftpFileTaskLaunchChannel", outputChannel = Source.OUTPUT)
-	public MessageProcessor<Message> sftpFileTaskLauncherTransformer() {
+	public MessageProcessor<Message> standaloneTaskLaunchRequestTransformer() {
 		return message -> {
 			TaskLaunchRequest outboundPayload = new TaskLaunchRequest(sftpSourceTaskProperties.getResourceUri(),
 				getCommandLineArgs(message), getEnvironmentProperties(), getDeploymentProperties(), null);
@@ -118,6 +120,7 @@ public class SftpSourceTaskLauncherConfiguration {
 		Map<String, String> environmentProperties = new HashMap<>();
 		environmentProperties.put(DATASOURCE_URL_PROPERTY_KEY, sftpSourceTaskProperties.getDataSourceUrl());
 		environmentProperties.put(DATASOURCE_USERNAME_PROPERTY_KEY, sftpSourceTaskProperties.getDataSourceUserName());
+		environmentProperties.put(DATASOURCE_PASSWORD_PROPERTY_KEY, sftpSourceTaskProperties.getDataSourcePassword());
 		environmentProperties.put(SFTP_HOST_PROPERTY_KEY, sftpSourceProperties.getFactory().getHost());
 		environmentProperties.put(SFTP_USERNAME_PROPERTY_KEY, sftpSourceProperties.getFactory().getUsername());
 		environmentProperties.put(SFTP_PASSWORD_PROPERTY_KEY, sftpSourceProperties.getFactory().getPassword());

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherConfiguration.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherConfiguration.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -30,10 +32,12 @@ import org.springframework.cloud.stream.app.sftp.source.batch.SftpSourceBatchPro
 import org.springframework.cloud.stream.app.sftp.source.metadata.SftpSourceIdempotentReceiverConfiguration;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.cloud.task.launcher.TaskLaunchRequest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.integration.annotation.IdempotentReceiver;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.file.FileHeaders;
+import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
@@ -43,6 +47,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * @author Chris Schaefer
+ * @author David Turanski
  */
 @EnableConfigurationProperties({ SftpSourceProperties.class, SftpSourceBatchProperties.class })
 @Import({ SftpSourceIdempotentReceiverConfiguration.class })
@@ -66,21 +71,47 @@ public class SftpSourceTaskLauncherConfiguration {
 
 	@Autowired
 	public SftpSourceTaskLauncherConfiguration(SftpSourceProperties sftpSourceProperties,
-			SftpSourceBatchProperties sftpSourceBatchProperties) {
+		SftpSourceBatchProperties sftpSourceBatchProperties) {
 		this.sftpSourceProperties = sftpSourceProperties;
 		this.sftpSourceBatchProperties = sftpSourceBatchProperties;
+		if (sftpSourceProperties.getTaskLauncherOutput() == SftpSourceProperties.TaskLaunchRequestType.DATAFLOW) {
+			Assert.hasText(sftpSourceBatchProperties.getApplicationName(),
+				"'applicationName' is required for DataFlow Task Launcher.");
+		}
 	}
 
-	@ConditionalOnProperty(name = "sftp.taskLauncherOutput")
+	@Bean
+	@ConditionalOnProperty(name = "sftp.taskLauncherOutput", havingValue = "STANDALONE")
 	@IdempotentReceiver("idempotentReceiverInterceptor")
 	@ServiceActivator(inputChannel = "sftpFileTaskLaunchChannel", outputChannel = Source.OUTPUT)
-	public Message sftpFileTaskLauncherTransformer(Message message) {
-		TaskLaunchRequest outboundPayload =
-				new TaskLaunchRequest(sftpSourceBatchProperties.getBatchResourceUri(), getCommandLineArgs(message),
-						getEnvironmentProperties(), getDeploymentProperties(), null);
-		return MessageBuilder.withPayload(outboundPayload).copyHeaders(message.getHeaders())
-				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON).build();
+	public MessageProcessor<Message> sftpFileTaskLauncherTransformer() {
+		return message -> {
+			TaskLaunchRequest outboundPayload = new TaskLaunchRequest(sftpSourceBatchProperties.getBatchResourceUri(),
+				getCommandLineArgs(message), getEnvironmentProperties(), getDeploymentProperties(), null);
+			return MessageBuilder.withPayload(outboundPayload)
+				.copyHeaders(message.getHeaders())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON)
+				.build();
+		};
 	}
+
+	@Bean
+	@ConditionalOnProperty(name = "sftp.taskLauncherOutput", havingValue = "DATAFLOW")
+	@IdempotentReceiver("idempotentReceiverInterceptor")
+	@ServiceActivator(inputChannel = "sftpFileTaskLaunchChannel", outputChannel = Source.OUTPUT)
+	public MessageProcessor<Message> dataflowTaskLauchRequestTransformer() {
+		return message -> {
+			DataFlowTaskLaunchRequest taskLaunchRequest = new DataFlowTaskLaunchRequest();
+			taskLaunchRequest.setCommandlineArguments(getCommandLineArgs(message));
+			taskLaunchRequest.setDeploymentProperties(getDeploymentProperties());
+			taskLaunchRequest.setApplicationName(sftpSourceBatchProperties.getApplicationName());
+			return MessageBuilder.withPayload(taskLaunchRequest)
+				.copyHeaders(message.getHeaders())
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON)
+				.build();
+		};
+	}
+
 
 	private Map<String, String> getEnvironmentProperties() {
 		Map<String, String> environmentProperties = new HashMap<>();
@@ -153,6 +184,42 @@ public class SftpSourceTaskLauncherConfiguration {
 		commandLineArgs.addAll(sftpSourceBatchProperties.getJobParameters());
 
 		return commandLineArgs;
+	}
+
+	static class DataFlowTaskLaunchRequest {
+		@JsonProperty("args")
+		private List<String> commandlineArguments = new ArrayList<>();
+		@JsonProperty("deploymentProps")
+		private Map<String, String> deploymentProperties = new HashMap<>();
+		@JsonProperty("name")
+		private String applicationName;
+
+		public List<String> getCommandlineArguments() {
+			return commandlineArguments;
+		}
+
+		public void setCommandlineArguments(List<String> commandlineArguments) {
+			Assert.notNull(commandlineArguments, "'commandLineArguments' cannot be null.");
+			this.commandlineArguments = commandlineArguments;
+		}
+
+		public Map<String, String> getDeploymentProperties() {
+			return deploymentProperties;
+		}
+
+		public void setDeploymentProperties(Map<String, String> deploymentProperties) {
+			Assert.notNull(commandlineArguments, "'deploymentProperties' cannot be null.");
+			this.deploymentProperties = deploymentProperties;
+		}
+
+		public String getApplicationName() {
+			return applicationName;
+		}
+
+		public void setApplicationName(String applicationName) {
+			Assert.hasText(applicationName, "'applicationName' cannot be blank.");
+			this.applicationName = applicationName;
+		}
 	}
 
 }

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherConfiguration.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherConfiguration.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.app.sftp.source.SftpSourceProperties;
@@ -81,7 +82,7 @@ public class SftpSourceTaskLauncherConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnProperty(name = "sftp.taskLauncherOutput", havingValue = "STANDALONE")
+	@ConditionalOnProperty(name = "sftp.task-launcher-output", havingValue = "STANDALONE")
 	@IdempotentReceiver("idempotentReceiverInterceptor")
 	@ServiceActivator(inputChannel = "sftpFileTaskLaunchChannel", outputChannel = Source.OUTPUT)
 	public MessageProcessor<Message> sftpFileTaskLauncherTransformer() {
@@ -96,7 +97,7 @@ public class SftpSourceTaskLauncherConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnProperty(name = "sftp.taskLauncherOutput", havingValue = "DATAFLOW")
+	@ConditionalOnProperty(name = "sftp.task-launcher-output", havingValue = "DATAFLOW")
 	@IdempotentReceiver("idempotentReceiverInterceptor")
 	@ServiceActivator(inputChannel = "sftpFileTaskLaunchChannel", outputChannel = Source.OUTPUT)
 	public MessageProcessor<Message> dataflowTaskLauchRequestTransformer() {

--- a/spring-cloud-starter-stream-source-sftp/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
+++ b/spring-cloud-starter-stream-source-sftp/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
@@ -1,7 +1,6 @@
 configuration-properties.classes=org.springframework.cloud.stream.app.sftp.source.SftpSourceProperties, \
-  org.springframework.cloud.stream.app.sftp.source.batch.SftpSourceBatchProperties, \
+  org.springframework.cloud.stream.app.sftp.source.task.SftpSourceTaskProperties, \
   org.springframework.cloud.stream.app.sftp.source.SftpSourceProperties$Factory, \
-  org.springframework.cloud.stream.app.sftp.source.metadata.SftpSourceRedisIdempotentReceiverProperties, \
   org.springframework.cloud.stream.app.file.FileConsumerProperties, \
   org.springframework.cloud.stream.app.trigger.TriggerPropertiesMaxMessagesDefaultUnlimited
 

--- a/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/SftpSourcePropertiesTests.java
+++ b/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/SftpSourcePropertiesTests.java
@@ -15,12 +15,6 @@
 
 package org.springframework.cloud.stream.app.sftp.source;
 
-import static org.hamcrest.CoreMatchers.endsWith;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.File;
 
 import org.junit.Test;
@@ -36,11 +30,18 @@ import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.test.util.TestUtils;
 
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 /**
  * @author David Turanski
  * @author Gary Russell
  * @author Artem Bilan
  * @author Chris Schaefer
+ * @author David Turanski
  */
 public class SftpSourcePropertiesTests {
 
@@ -145,17 +146,17 @@ public class SftpSourcePropertiesTests {
 	@Test
 	public void taskLauncherOutputCanBeCustomized() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
-		testPropertyValues(context, "sftp.taskLauncherOutput:true");
+		testPropertyValues(context, "sftp.taskLauncherOutput:STANDALONE");
 		context.register(Conf.class);
 		context.refresh();
 		SftpSourceProperties properties = context.getBean(SftpSourceProperties.class);
-		assertTrue(properties.isTaskLauncherOutput());
+		assertTrue(properties.getTaskLauncherOutput() == SftpSourceProperties.TaskLaunchRequestType.STANDALONE);
 	}
 
 	@Test(expected = AssertionError.class)
 	public void onlyAllowListOnlyOrTaskLauncherOutputEnabled() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
-		testPropertyValues(context, "sftp.listOnly:true", "sftp.taskLauncherOutput:true");
+		testPropertyValues(context, "sftp.listOnly:true", "sftp.taskLauncherOutput:STANDALONE");
 		context.register(Conf.class);
 
 		try {
@@ -193,13 +194,13 @@ public class SftpSourcePropertiesTests {
 	public void knownHostsExpression() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 		testPropertyValues(context,
-				"sftp.factory.known-hosts-expression = @systemProperties[\"user.home\"] + \"/.ssh/known_hosts\"",
-				"sftp.factory.cache-sessions = true");
+			"sftp.factory.known-hosts-expression = @systemProperties[\"user.home\"] + \"/.ssh/known_hosts\"",
+			"sftp.factory.cache-sessions = true");
 		context.register(Factory.class);
 		context.refresh();
 		SessionFactory<?> sessionFactory = context.getBean(SessionFactory.class);
-		assertThat((String) TestUtils.getPropertyValue(sessionFactory, "sessionFactory.knownHosts"), endsWith(
-				"/.ssh/known_hosts"));
+		assertThat((String) TestUtils.getPropertyValue(sessionFactory, "sessionFactory.knownHosts"),
+			endsWith("/.ssh/known_hosts"));
 		context.close();
 	}
 

--- a/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/task/SftpSourceTaskPropertiesTests.java
+++ b/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/task/SftpSourceTaskPropertiesTests.java
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.stream.app.sftp.source.batch;
+package org.springframework.cloud.stream.app.sftp.source.task;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,101 +35,101 @@ import org.springframework.integration.config.EnableIntegration;
 /**
  * @author Chris Schaefer
  */
-public class SftpSourceBatchPropertiesTests {
+public class SftpSourceTaskPropertiesTests {
 
 	@Test
 	public void batchUriCanBeCustomized() {
-		SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.batchResourceUri:uri:/somewhere");
-		assertThat(properties.getBatchResourceUri(), equalTo("uri:/somewhere"));
+		SftpSourceTaskProperties properties = getBatchProperties("sftp.task.resourceUri:uri:/somewhere");
+		assertThat(properties.getResourceUri(), equalTo("uri:/somewhere"));
 	}
 
 	@Test(expected = AssertionError.class)
 	public void batchUriIsRequired() {
-		validateRequiredProperty("sftp.batch.batchResourceUri");
+		validateRequiredProperty("sftp.task.resourceUri");
 	}
 
 	@Test
 	public void dataSourceUrlCanBeCustomized() {
-		SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.dataSourceUrl:jdbc:h2:tcp://localhost/mem:df");
+		SftpSourceTaskProperties properties = getBatchProperties("sftp.task.dataSourceUrl:jdbc:h2:tcp://localhost/mem:df");
 		assertThat(properties.getDataSourceUrl(), equalTo("jdbc:h2:tcp://localhost/mem:df"));
 	}
 
 	@Test(expected = AssertionError.class)
 	public void dataSourceUrlIsRequired() {
-		validateRequiredProperty("sftp.batch.dataSourceUrl");
+		validateRequiredProperty("sftp.task.dataSourceUrl");
 	}
 
 	@Test
 	public void dataSourceUsernameCanBeCustomized() {
-		SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.dataSourceUserName:user");
+		SftpSourceTaskProperties properties = getBatchProperties("sftp.task.dataSourceUserName:user");
 		assertThat(properties.getDataSourceUserName(), equalTo("user"));
 	}
 
 	@Test(expected = AssertionError.class)
 	public void dataSourceUsernameIsRequired() {
-		validateRequiredProperty("sftp.batch.dataSourceUserName");
+		validateRequiredProperty("sftp.task.dataSourceUserName");
 	}
 
 	@Test
 	public void dataSourcePasswordCanBeCustomized() {
-		SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.dataSourcePassword:pass");
+		SftpSourceTaskProperties properties = getBatchProperties("sftp.task.dataSourcePassword:pass");
 		assertThat(properties.getDataSourcePassword(), equalTo("pass"));
 	}
 
 	@Test
 	public void deploymentPropertiesCanBeCustomized() {
-		SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.deploymentProperties:prop1=val1,prop2=val2");
+		SftpSourceTaskProperties properties = getBatchProperties("sftp.task.deploymentProperties:prop1=val1,prop2=val2");
 		assertThat(properties.getDeploymentProperties(), equalTo("prop1=val1,prop2=val2"));
 	}
 
 	@Test
 	public void environmentPropertiesCanBeCustomized() {
-		SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.environmentProperties:prop1=val1,prop2=val2");
+		SftpSourceTaskProperties properties = getBatchProperties("sftp.task.environmentProperties:prop1=val1,prop2=val2");
 		assertThat(properties.getEnvironmentProperties(), equalTo("prop1=val1,prop2=val2"));
 	}
 
 	@Test
-	public void remoteFilePathJobParameterNameCanBeCustomized() {
-		SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.remoteFilePathJobParameterName:externalFileName");
-		assertThat(properties.getRemoteFilePathJobParameterName(), equalTo("externalFileName"));
+	public void remoteFilePathParameterNameCanBeCustomized() {
+		SftpSourceTaskProperties properties = getBatchProperties("sftp.task.remoteFilePathParameterName:externalFileName");
+		assertThat(properties.getRemoteFilePathParameterName(), equalTo("externalFileName"));
 	}
 
 	@Test
-	public void remoteFilePathJobParameterNameDefault() {
-		SftpSourceBatchProperties properties = getBatchProperties(null);
-		assertThat(properties.getRemoteFilePathJobParameterName(), equalTo(SftpSourceBatchProperties.DEFAULT_REMOTE_FILE_PATH_JOB_PARAM_NAME));
+	public void remoteFilePathParameterNameDefault() {
+		SftpSourceTaskProperties properties = getBatchProperties(null);
+		assertThat(properties.getRemoteFilePathParameterName(), equalTo(SftpSourceTaskProperties.DEFAULT_REMOTE_FILE_PATH_PARAM_NAME));
 	}
 
 	@Test
-	public void localFilePathJobParameterNameCanBeCustomized() {
-		SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.localFilePathJobParameterName:localFileName");
-		assertThat(properties.getLocalFilePathJobParameterName(), equalTo("localFileName"));
+	public void localFilePathParameterNameCanBeCustomized() {
+		SftpSourceTaskProperties properties = getBatchProperties("sftp.task.localFilePathParameterName:localFileName");
+		assertThat(properties.getLocalFilePathParameterName(), equalTo("localFileName"));
 	}
 
 	@Test
-	public void localFilePathJobParameterNameDefault() {
-		SftpSourceBatchProperties properties = getBatchProperties(null);
-		assertThat(properties.getLocalFilePathJobParameterName(), equalTo(SftpSourceBatchProperties.DEFAULT_LOCAL_FILE_PATH_JOB_PARAM_NAME));
+	public void localFilePathParameterNameDefault() {
+		SftpSourceTaskProperties properties = getBatchProperties(null);
+		assertThat(properties.getLocalFilePathParameterName(), equalTo(SftpSourceTaskProperties.DEFAULT_LOCAL_FILE_PATH_PARAM_NAME));
 	}
 
 	@Test
-	public void localFilePathJobParameterValueCanBeCustomized() {
-		SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.localFilePathJobParameterValue:/home/files");
-		assertThat(properties.getLocalFilePathJobParameterValue(), equalTo("/home/files"));
+	public void localFilePathParameterValueCanBeCustomized() {
+		SftpSourceTaskProperties properties = getBatchProperties("sftp.task.localFilePathParameterValue:/home/files");
+		assertThat(properties.getLocalFilePathParameterValue(), equalTo("/home/files"));
 	}
 
 	@Test
-	public void jobParametersCanBeCustomized() {
-		SftpSourceBatchProperties properties = getBatchProperties("sftp.batch.jobParameters:jp1=jpv1,jp2=jpv2");
-		List<String> jobParameters = properties.getJobParameters();
+	public void parametersCanBeCustomized() {
+		SftpSourceTaskProperties properties = getBatchProperties("sftp.task.Parameters:jp1=jpv1,jp2=jpv2");
+		List<String> jobParameters = properties.getParameters();
 
-		assertNotNull("Job parameters should not be null", jobParameters);
-		assertThat("Expected two job parameters", jobParameters.size() == 2);
+		assertNotNull("Parameters should not be null", jobParameters);
+		assertThat("Expected two parameters", jobParameters.size() == 2);
 		assertThat(jobParameters.get(0), equalTo("jp1=jpv1"));
 		assertThat(jobParameters.get(1), equalTo("jp2=jpv2"));
 	}
 
-	private SftpSourceBatchProperties getBatchProperties(String var) {
+	private SftpSourceTaskProperties getBatchProperties(String var) {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
 		if (var != null) {
@@ -139,7 +139,7 @@ public class SftpSourceBatchPropertiesTests {
 		context.register(Conf.class);
 		context.refresh();
 
-		return context.getBean(SftpSourceBatchProperties.class);
+		return context.getBean(SftpSourceTaskProperties.class);
 	}
 
 	private void validateRequiredProperty(String property) {
@@ -155,7 +155,7 @@ public class SftpSourceBatchPropertiesTests {
 
 	@Configuration
 	@EnableIntegration
-	@EnableConfigurationProperties(SftpSourceBatchProperties.class)
+	@EnableConfigurationProperties(SftpSourceTaskProperties.class)
 	@Import(SpelExpressionConverterConfiguration.class)
 	static class Conf {
 

--- a/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherIntegrationTests.java
+++ b/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherIntegrationTests.java
@@ -15,27 +15,22 @@
 
 package org.springframework.cloud.stream.app.sftp.source.tasklauncher;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.app.test.sftp.SftpTestSupport;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.cloud.task.launcher.TaskLaunchRequest;
+import org.springframework.http.MediaType;
 import org.springframework.integration.metadata.ConcurrentMetadataStore;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
@@ -44,19 +39,19 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.MimeTypeUtils;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
 
 /**
  * @author Chris Schaefer
+ * @author David Turanski
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		properties = {
-				"sftp.remoteDir = sftpSource",
-				"sftp.factory.username = foo",
-				"sftp.factory.password = foo",
-				"sftp.factory.allowUnknownKeys = true"
-		})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = { "sftp.remoteDir = sftpSource",
+	"sftp.factory.username = foo", "sftp.factory.password = foo", "sftp.factory.allowUnknownKeys = true" })
 @DirtiesContext
 public abstract class SftpSourceTaskLauncherIntegrationTests extends SftpTestSupport {
 
@@ -69,59 +64,51 @@ public abstract class SftpSourceTaskLauncherIntegrationTests extends SftpTestSup
 	@Autowired
 	protected ConcurrentMetadataStore metadataStore;
 
-	@TestPropertySource(properties = {
-			"sftp.taskLauncherOutput = true",
-			"sftp.batch.batchResourceUri = file://some.jar",
-			"sftp.batch.dataSourceUserName = sa",
-			"sftp.batch.dataSourceUrl = jdbc://host:2222/mem",
-			"sftp.batch.localFilePathJobParameterValue = /tmp/files/",
-			"sftp.batch.jobParameters = jpk1=jpv1,jpk2=jpv2",
-			"sftp.factory.host = 127.0.0.1",
-			"sftp.factory.username = user",
-			"sftp.factory.password = pass"
-	})
+	@TestPropertySource(properties = { "sftp.taskLauncherOutput = STANDALONE",
+		"sftp.batch.batchResourceUri = file://some.jar", "sftp.batch.dataSourceUserName = sa",
+		"sftp.batch.dataSourceUrl = jdbc://host:2222/mem", "sftp.batch.localFilePathJobParameterValue = /tmp/files/",
+		"sftp.batch.jobParameters = jpk1=jpv1,jpk2=jpv2", "sftp.factory.host = 127.0.0.1",
+		"sftp.factory.username = user", "sftp.factory.password = pass" })
 	public static class TaskLauncherOutputTests extends SftpSourceTaskLauncherIntegrationTests {
 
 		@Test
 		public void pollAndAssertFiles() throws Exception {
 			for (int i = 1; i <= 2; i++) {
-				@SuppressWarnings("unchecked")
-				Message<?> received = this.messageCollector.forChannel(this.sftpSource.output())
-						.poll(10, TimeUnit.SECONDS);
+				@SuppressWarnings("unchecked") Message<?> received = this.messageCollector.forChannel(
+					this.sftpSource.output()).poll(10, TimeUnit.SECONDS);
 
 				assertNotNull("No files were received", received);
 				assertThat(received.getPayload(), instanceOf(String.class));
 
 				assertEquals(MimeTypeUtils.APPLICATION_JSON, received.getHeaders().get(MessageHeaders.CONTENT_TYPE));
-				TaskLaunchRequest taskLaunchRequest = new ObjectMapper()
-						.readValue((String) received.getPayload(), TaskLaunchRequest.class);
+				TaskLaunchRequest taskLaunchRequest = new ObjectMapper().readValue((String) received.getPayload(),
+					TaskLaunchRequest.class);
 				assertNotNull(taskLaunchRequest);
 
 				assertEquals("Unexpected number of deployment properties", 0,
-						taskLaunchRequest.getDeploymentProperties().size());
+					taskLaunchRequest.getDeploymentProperties().size());
 				assertEquals("Unexpected batch artifact URI", "file://some.jar", taskLaunchRequest.getUri());
 
 				Map<String, String> environmentProperties = taskLaunchRequest.getEnvironmentProperties();
 				assertEquals("Unexpected datasource user name", "sa",
-						environmentProperties
-								.get(SftpSourceTaskLauncherConfiguration.DATASOURCE_USERNAME_PROPERTY_KEY));
+					environmentProperties.get(SftpSourceTaskLauncherConfiguration.DATASOURCE_USERNAME_PROPERTY_KEY));
 				assertEquals("Unexpected datasource url", "jdbc://host:2222/mem",
-						environmentProperties.get(SftpSourceTaskLauncherConfiguration.DATASOURCE_URL_PROPERTY_KEY));
+					environmentProperties.get(SftpSourceTaskLauncherConfiguration.DATASOURCE_URL_PROPERTY_KEY));
 				assertEquals("Unexpected SFTP host", "127.0.0.1",
-						environmentProperties.get(SftpSourceTaskLauncherConfiguration.SFTP_HOST_PROPERTY_KEY));
+					environmentProperties.get(SftpSourceTaskLauncherConfiguration.SFTP_HOST_PROPERTY_KEY));
 				assertEquals("Unexpected SFTP username", "user",
-						environmentProperties.get(SftpSourceTaskLauncherConfiguration.SFTP_USERNAME_PROPERTY_KEY));
+					environmentProperties.get(SftpSourceTaskLauncherConfiguration.SFTP_USERNAME_PROPERTY_KEY));
 				assertEquals("Unexpected SFTP password", "pass",
-						environmentProperties.get(SftpSourceTaskLauncherConfiguration.SFTP_PASSWORD_PROPERTY_KEY));
+					environmentProperties.get(SftpSourceTaskLauncherConfiguration.SFTP_PASSWORD_PROPERTY_KEY));
 				assertNotNull("SFTP port is null",
-						environmentProperties.get(SftpSourceTaskLauncherConfiguration.SFTP_PORT_PROPERTY_KEY));
+					environmentProperties.get(SftpSourceTaskLauncherConfiguration.SFTP_PORT_PROPERTY_KEY));
 
 				List<String> commandlineArguments = taskLaunchRequest.getCommandlineArguments();
 				assertEquals("Unexpected number of commandline arguments", 4, commandlineArguments.size());
 				assertEquals("Unexpected remote file path", "remoteFilePath=sftpSource/sftpSource" + i + ".txt",
-						commandlineArguments.get(0));
+					commandlineArguments.get(0));
 				assertEquals("Unexpected local file path", "localFilePath=/tmp/files/sftpSource" + i + ".txt",
-						commandlineArguments.get(1));
+					commandlineArguments.get(1));
 				assertEquals("Unexpected job parameter", "jpk1=jpv1", commandlineArguments.get(2));
 				assertEquals("Unexpected job parameter", "jpk2=jpv2", commandlineArguments.get(3));
 			}
@@ -132,4 +119,45 @@ public abstract class SftpSourceTaskLauncherIntegrationTests extends SftpTestSup
 
 	}
 
+	@TestPropertySource(properties = { "sftp.taskLauncherOutput = DATAFLOW", "sftp.batch.applicationName=task",
+		"sftp.factory.allowUnknownKeys = true", "sftp.remoteDir = sftpSource", "sftp.factory.host = 127.0.0.1",
+		"sftp.factory.username = user",
+		"sftp.factory.password = pass",
+		"logging.level.org.springframework.integration = DEBUG" })
+	public static class SftpSourceDataFlowTaskLauncherIntegrationTests extends SftpSourceTaskLauncherIntegrationTests {
+
+		@Autowired
+		MessageCollector messageCollector;
+
+		@Autowired
+		Source sftpSource;
+
+		@Autowired
+		private ObjectMapper objectMapper;
+
+		@Autowired
+		protected ConcurrentMetadataStore metadataStore;
+
+		@Test
+		public void outputIsCorrect() throws Exception {
+
+			for (int i = 1; i <= 2; i++) {
+				@SuppressWarnings("unchecked") Message<?> received = this.messageCollector.forChannel(
+					this.sftpSource.output()).poll(10, TimeUnit.SECONDS);
+
+				assertNotNull("No files were received", received);
+
+				Assertions.assertThat(received.getHeaders().get(MessageHeaders.CONTENT_TYPE))
+					.isEqualTo(MediaType.APPLICATION_JSON);
+
+				SftpSourceTaskLauncherConfiguration.DataFlowTaskLaunchRequest dataFlowTaskLaunchRequest = objectMapper.readValue(
+					(String) received.getPayload(),
+					SftpSourceTaskLauncherConfiguration.DataFlowTaskLaunchRequest.class);
+				Assertions.assertThat(dataFlowTaskLaunchRequest.getApplicationName()).isEqualTo("task");
+				Assertions.assertThat(dataFlowTaskLaunchRequest.getCommandlineArguments())
+					.containsAnyOf("remoteFilePath=sftpSource/sftpSource1.txt",
+						"remoteFilePath=sftpSource/sftpSource2.txt");
+			}
+		}
+	}
 }

--- a/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherIntegrationTests.java
+++ b/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherIntegrationTests.java
@@ -65,9 +65,9 @@ public abstract class SftpSourceTaskLauncherIntegrationTests extends SftpTestSup
 	protected ConcurrentMetadataStore metadataStore;
 
 	@TestPropertySource(properties = { "sftp.taskLauncherOutput = STANDALONE",
-		"sftp.batch.batchResourceUri = file://some.jar", "sftp.batch.dataSourceUserName = sa",
-		"sftp.batch.dataSourceUrl = jdbc://host:2222/mem", "sftp.batch.localFilePathJobParameterValue = /tmp/files/",
-		"sftp.batch.jobParameters = jpk1=jpv1,jpk2=jpv2", "sftp.factory.host = 127.0.0.1",
+		"sftp.task.resourceUri = file://some.jar", "sftp.task.dataSourceUserName = sa",
+		"sftp.task.dataSourceUrl = jdbc://host:2222/mem", "sftp.task.localFilePathParameterValue = /tmp/files/",
+		"sftp.task.Parameters = jpk1=jpv1,jpk2=jpv2", "sftp.factory.host = 127.0.0.1",
 		"sftp.factory.username = user", "sftp.factory.password = pass" })
 	public static class TaskLauncherOutputTests extends SftpSourceTaskLauncherIntegrationTests {
 
@@ -87,7 +87,7 @@ public abstract class SftpSourceTaskLauncherIntegrationTests extends SftpTestSup
 
 				assertEquals("Unexpected number of deployment properties", 0,
 					taskLaunchRequest.getDeploymentProperties().size());
-				assertEquals("Unexpected batch artifact URI", "file://some.jar", taskLaunchRequest.getUri());
+				assertEquals("Unexpected task artifact URI", "file://some.jar", taskLaunchRequest.getUri());
 
 				Map<String, String> environmentProperties = taskLaunchRequest.getEnvironmentProperties();
 				assertEquals("Unexpected datasource user name", "sa",
@@ -109,8 +109,8 @@ public abstract class SftpSourceTaskLauncherIntegrationTests extends SftpTestSup
 					commandlineArguments.get(0));
 				assertEquals("Unexpected local file path", "localFilePath=/tmp/files/sftpSource" + i + ".txt",
 					commandlineArguments.get(1));
-				assertEquals("Unexpected job parameter", "jpk1=jpv1", commandlineArguments.get(2));
-				assertEquals("Unexpected job parameter", "jpk2=jpv2", commandlineArguments.get(3));
+				assertEquals("Unexpected  parameter", "jpk1=jpv1", commandlineArguments.get(2));
+				assertEquals("Unexpected  parameter", "jpk2=jpv2", commandlineArguments.get(3));
 			}
 
 			assertNotNull(this.metadataStore.get("sftpSource/sftpSource1.txt"));
@@ -119,7 +119,7 @@ public abstract class SftpSourceTaskLauncherIntegrationTests extends SftpTestSup
 
 	}
 
-	@TestPropertySource(properties = { "sftp.taskLauncherOutput = DATAFLOW", "sftp.batch.applicationName=task",
+	@TestPropertySource(properties = { "sftp.taskLauncherOutput = DATAFLOW", "sftp.task.applicationName=task",
 		"sftp.factory.allowUnknownKeys = true", "sftp.remoteDir = sftpSource", "sftp.factory.host = 127.0.0.1",
 		"sftp.factory.username = user",
 		"sftp.factory.password = pass",

--- a/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherParsingTests.java
+++ b/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherParsingTests.java
@@ -22,10 +22,12 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import org.springframework.cloud.stream.app.sftp.source.SftpSourceProperties;
 import org.springframework.cloud.stream.app.sftp.source.batch.SftpSourceBatchProperties;
 
 /**
  * @author Chris Schaefer
+ * @author David Turanski
  */
 public class SftpSourceTaskLauncherParsingTests {
 	@Test
@@ -33,7 +35,7 @@ public class SftpSourceTaskLauncherParsingTests {
 		SftpSourceBatchProperties sftpSourceBatchProperties = new SftpSourceBatchProperties();
 
 		SftpSourceTaskLauncherConfiguration sftpSourceTaskLauncherConfiguration =
-				new SftpSourceTaskLauncherConfiguration(null, sftpSourceBatchProperties);
+				new SftpSourceTaskLauncherConfiguration(new SftpSourceProperties(), sftpSourceBatchProperties);
 
 		sftpSourceBatchProperties.setDeploymentProperties("app.sftp.param=value");
 
@@ -48,7 +50,7 @@ public class SftpSourceTaskLauncherParsingTests {
 		SftpSourceBatchProperties sftpSourceBatchProperties = new SftpSourceBatchProperties();
 
 		SftpSourceTaskLauncherConfiguration sftpSourceTaskLauncherConfiguration =
-				new SftpSourceTaskLauncherConfiguration(null, sftpSourceBatchProperties);
+				new SftpSourceTaskLauncherConfiguration(new SftpSourceProperties(), sftpSourceBatchProperties);
 
 		sftpSourceBatchProperties.setDeploymentProperties("app.sftp.param=value1,value2");
 
@@ -63,7 +65,7 @@ public class SftpSourceTaskLauncherParsingTests {
 		SftpSourceBatchProperties sftpSourceBatchProperties = new SftpSourceBatchProperties();
 
 		SftpSourceTaskLauncherConfiguration sftpSourceTaskLauncherConfiguration =
-				new SftpSourceTaskLauncherConfiguration(null, sftpSourceBatchProperties);
+				new SftpSourceTaskLauncherConfiguration(new SftpSourceProperties(), sftpSourceBatchProperties);
 
 		sftpSourceBatchProperties.setDeploymentProperties("app.sftp.param=value1,app.sftp.other.param=value2");
 
@@ -80,7 +82,7 @@ public class SftpSourceTaskLauncherParsingTests {
 		SftpSourceBatchProperties sftpSourceBatchProperties = new SftpSourceBatchProperties();
 
 		SftpSourceTaskLauncherConfiguration sftpSourceTaskLauncherConfiguration =
-				new SftpSourceTaskLauncherConfiguration(null, sftpSourceBatchProperties);
+				new SftpSourceTaskLauncherConfiguration(new SftpSourceProperties(), sftpSourceBatchProperties);
 
 		sftpSourceBatchProperties.setDeploymentProperties("app.sftp.param=value1,value2,app.sftp.other.param=other1,other2");
 

--- a/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherParsingTests.java
+++ b/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/tasklauncher/SftpSourceTaskLauncherParsingTests.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import org.springframework.cloud.stream.app.sftp.source.SftpSourceProperties;
-import org.springframework.cloud.stream.app.sftp.source.batch.SftpSourceBatchProperties;
+import org.springframework.cloud.stream.app.sftp.source.task.SftpSourceTaskProperties;
 
 /**
  * @author Chris Schaefer
@@ -32,12 +32,12 @@ import org.springframework.cloud.stream.app.sftp.source.batch.SftpSourceBatchPro
 public class SftpSourceTaskLauncherParsingTests {
 	@Test
 	public void testParseSimpleDeploymentProperty() {
-		SftpSourceBatchProperties sftpSourceBatchProperties = new SftpSourceBatchProperties();
+		SftpSourceTaskProperties sftpSourceTaskProperties = new SftpSourceTaskProperties();
 
 		SftpSourceTaskLauncherConfiguration sftpSourceTaskLauncherConfiguration =
-				new SftpSourceTaskLauncherConfiguration(new SftpSourceProperties(), sftpSourceBatchProperties);
+				new SftpSourceTaskLauncherConfiguration(new SftpSourceProperties(), sftpSourceTaskProperties);
 
-		sftpSourceBatchProperties.setDeploymentProperties("app.sftp.param=value");
+		sftpSourceTaskProperties.setDeploymentProperties("app.sftp.param=value");
 
 		Map<String, String> deploymentProperties = sftpSourceTaskLauncherConfiguration.getDeploymentProperties();
 		assertTrue("Invalid number of deployment properties: " + deploymentProperties.size(), deploymentProperties.size() == 1);
@@ -47,12 +47,12 @@ public class SftpSourceTaskLauncherParsingTests {
 
 	@Test
 	public void testParseSimpleDeploymentPropertyMultipleValues() {
-		SftpSourceBatchProperties sftpSourceBatchProperties = new SftpSourceBatchProperties();
+		SftpSourceTaskProperties sftpSourceTaskProperties = new SftpSourceTaskProperties();
 
 		SftpSourceTaskLauncherConfiguration sftpSourceTaskLauncherConfiguration =
-				new SftpSourceTaskLauncherConfiguration(new SftpSourceProperties(), sftpSourceBatchProperties);
+				new SftpSourceTaskLauncherConfiguration(new SftpSourceProperties(), sftpSourceTaskProperties);
 
-		sftpSourceBatchProperties.setDeploymentProperties("app.sftp.param=value1,value2");
+		sftpSourceTaskProperties.setDeploymentProperties("app.sftp.param=value1,value2");
 
 		Map<String, String> deploymentProperties = sftpSourceTaskLauncherConfiguration.getDeploymentProperties();
 		assertTrue("Invalid number of deployment properties: " + deploymentProperties.size(), deploymentProperties.size() == 1);
@@ -62,12 +62,12 @@ public class SftpSourceTaskLauncherParsingTests {
 
 	@Test
 	public void testParseMultipleDeploymentPropertiesSingleValue() {
-		SftpSourceBatchProperties sftpSourceBatchProperties = new SftpSourceBatchProperties();
+		SftpSourceTaskProperties sftpSourceTaskProperties = new SftpSourceTaskProperties();
 
 		SftpSourceTaskLauncherConfiguration sftpSourceTaskLauncherConfiguration =
-				new SftpSourceTaskLauncherConfiguration(new SftpSourceProperties(), sftpSourceBatchProperties);
+				new SftpSourceTaskLauncherConfiguration(new SftpSourceProperties(), sftpSourceTaskProperties);
 
-		sftpSourceBatchProperties.setDeploymentProperties("app.sftp.param=value1,app.sftp.other.param=value2");
+		sftpSourceTaskProperties.setDeploymentProperties("app.sftp.param=value1,app.sftp.other.param=value2");
 
 		Map<String, String> deploymentProperties = sftpSourceTaskLauncherConfiguration.getDeploymentProperties();
 		assertTrue("Invalid number of deployment properties: " + deploymentProperties.size(), deploymentProperties.size() == 2);
@@ -79,12 +79,12 @@ public class SftpSourceTaskLauncherParsingTests {
 
 	@Test
 	public void testParseMultipleDeploymentPropertiesMultipleValues() {
-		SftpSourceBatchProperties sftpSourceBatchProperties = new SftpSourceBatchProperties();
+		SftpSourceTaskProperties sftpSourceTaskProperties = new SftpSourceTaskProperties();
 
 		SftpSourceTaskLauncherConfiguration sftpSourceTaskLauncherConfiguration =
-				new SftpSourceTaskLauncherConfiguration(new SftpSourceProperties(), sftpSourceBatchProperties);
+				new SftpSourceTaskLauncherConfiguration(new SftpSourceProperties(), sftpSourceTaskProperties);
 
-		sftpSourceBatchProperties.setDeploymentProperties("app.sftp.param=value1,value2,app.sftp.other.param=other1,other2");
+		sftpSourceTaskProperties.setDeploymentProperties("app.sftp.param=value1,value2,app.sftp.other.param=other1,other2");
 
 		Map<String, String> deploymentProperties = sftpSourceTaskLauncherConfiguration.getDeploymentProperties();
 		assertTrue("Invalid number of deployment properties: " + deploymentProperties.size(), deploymentProperties.size() == 2);


### PR DESCRIPTION
Fixes #21 and Fixes #22

* Change `sftp.task-launcher-output` from boolean to enum (NONE, STANDALONE, DATAFLOW). `STANDALONE` behaves as before with `sftp.task-launcher-output=true`. `DATAFLOW` outputs a Task Launch Request compatible with the `dataflow-task-launcher-sink`. 

NOTE this is a breaking change, so more to follow:

* The last commit changes the `sftp.batch` property prefix to `sftp.task` and removes `job` from property names. This is appropriate since the `TaskLaunchRequest` is provided by Spring-Cloud-Task, which is independent of, but supports Spring Batch. Since this PR adds the `application-name` property, `task.application-name` is more appropriate than `batch.application-name` and the same is true for all properties pertaining to the TLR. 

* Adds README content pertaining to Task Launch Requests.   

* Fixes the `@ConditionalOnProperty` intention in `SftpSourceTaskLauncherConfiguration`. The annotation had no effect since the method was only `@Transformer` and not `@Bean`.  Having this work correctly is required(convenient at least) for providing multiple `sftp.task-launcher-output` transformations.