### PR TITLE
GH-29: Use shared sftp session for source

### DIFF
--- a/spring-cloud-starter-stream-source-sftp/README.adoc
+++ b/spring-cloud-starter-stream-source-sftp/README.adoc
@@ -122,7 +122,6 @@ $$sftp.delete-remote-files$$:: $$Set to true to delete remote files after succes
 $$sftp.directories$$:: $$A list of factory "name.directory" pairs.$$ *($$String[]$$, default: `$$<none>$$`)*
 $$sftp.factories$$:: $$A map of factory names to factories.$$ *($$Map<String, Factory>$$, default: `$$<none>$$`)*
 $$sftp.factory.allow-unknown-keys$$:: $$True to allow an unknown or changed key.$$ *($$Boolean$$, default: `$$false$$`)*
-$$sftp.factory.cache-sessions$$:: $$Cache sessions$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$sftp.factory.host$$:: $$The host name of the server.$$ *($$String$$, default: `$$localhost$$`)*
 $$sftp.factory.known-hosts-expression$$:: $$A SpEL expression resolving to the location of the known hosts file.$$ *($$Expression$$, default: `$$<none>$$`)*
 $$sftp.factory.pass-phrase$$:: $$Passphrase for user's private key.$$ *($$String$$, default: `$$<empty string>$$`)*

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceProperties.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceProperties.java
@@ -311,11 +311,6 @@ public class SftpSourceProperties {
 		private String password;
 
 		/**
-		 * Cache sessions
-		 */
-		private Boolean cacheSessions;
-
-		/**
 		 * The port of the server.
 		 */
 		private int port = 22;
@@ -364,14 +359,6 @@ public class SftpSourceProperties {
 
 		public void setPassword(String password) {
 			this.password = password;
-		}
-
-		public Boolean getCacheSessions() {
-			return this.cacheSessions;
-		}
-
-		public void setCacheSessions(Boolean cacheSessions) {
-			this.cacheSessions = cacheSessions;
 		}
 
 		@Range(min = 0, max = 65535)

--- a/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceSessionFactoryConfiguration.java
+++ b/spring-cloud-starter-stream-source-sftp/src/main/java/org/springframework/cloud/stream/app/sftp/source/SftpSourceSessionFactoryConfiguration.java
@@ -37,6 +37,7 @@ import com.jcraft.jsch.ChannelSftp.LsEntry;
  * Session factory configuration.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  *
  */
 public class SftpSourceSessionFactoryConfiguration {
@@ -64,7 +65,7 @@ public class SftpSourceSessionFactoryConfiguration {
 	}
 
 	static SessionFactory<LsEntry> buildFactory(BeanFactory beanFactory, Factory factory) {
-		DefaultSftpSessionFactory sftpSessionFactory = new DefaultSftpSessionFactory();
+		DefaultSftpSessionFactory sftpSessionFactory = new DefaultSftpSessionFactory(true);
 		sftpSessionFactory.setHost(factory.getHost());
 		sftpSessionFactory.setPort(factory.getPort());
 		sftpSessionFactory.setUser(factory.getUsername());
@@ -74,13 +75,8 @@ public class SftpSourceSessionFactoryConfiguration {
 			sftpSessionFactory.setKnownHosts(factory.getKnownHostsExpression()
 					.getValue(IntegrationContextUtils.getEvaluationContext(beanFactory), String.class));
 		}
-		if (factory.getCacheSessions() != null) {
-			CachingSessionFactory<LsEntry> csf = new CachingSessionFactory<>(sftpSessionFactory);
-			return csf;
-		}
-		else {
-			return sftpSessionFactory;
-		}
+
+		return sftpSessionFactory;
 	}
 
 	final static class DelegatingFactoryWrapper implements DisposableBean {

--- a/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/SftpSourcePropertiesTests.java
+++ b/spring-cloud-starter-stream-source-sftp/src/test/java/org/springframework/cloud/stream/app/sftp/source/SftpSourcePropertiesTests.java
@@ -199,7 +199,7 @@ public class SftpSourcePropertiesTests {
 		context.register(Factory.class);
 		context.refresh();
 		SessionFactory<?> sessionFactory = context.getBean(SessionFactory.class);
-		assertThat((String) TestUtils.getPropertyValue(sessionFactory, "sessionFactory.knownHosts"),
+		assertThat((String) TestUtils.getPropertyValue(sessionFactory, "knownHosts"),
 			endsWith("/.ssh/known_hosts"));
 		context.close();
 	}


### PR DESCRIPTION
Fixes spring-cloud-stream-app-starters/sftp#29

The SFTP Source can just rely on the shared sftp session for polling
there is no any concurrency.
So, instead of configurable caching change source to always rely on the
shared sftp session